### PR TITLE
[feat] 온보팅 페이지 및  스타일 추가

### DIFF
--- a/src/pages/intro/Onboarding.jsx
+++ b/src/pages/intro/Onboarding.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as On from './OnboardingStyles.jsx';
+import Logo from '../../assets/Logo.png';
+
+const Onboarding = () => {
+    const navigate = useNavigate();
+
+    const goToSignUp = () => {
+        navigate('/signup');
+    };
+
+    return (
+        <On.Container>
+            <On.LogoImg>
+                <img src={Logo} />
+            </On.LogoImg>
+            <On.Title>
+                내 생각을 키워주는 AI 파트너 <br />
+                지금 시작해 보세요!
+            </On.Title>
+            <On.StartButton onClick={goToSignUp}>시작하기</On.StartButton>
+            <On.Login>
+                이미 계정이 있으신가요?
+                <On.LoginButton>로그인</On.LoginButton>
+            </On.Login>
+        </On.Container>
+    );
+};
+export default Onboarding;

--- a/src/pages/intro/OnboardingStyles.jsx
+++ b/src/pages/intro/OnboardingStyles.jsx
@@ -1,0 +1,55 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    min-height: 100vh;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background-color: #f9f9f9;
+`;
+
+export const LogoImg = styled.div`
+    img {
+        width: 280px;
+        height: 160px;
+    }
+`;
+
+export const Title = styled.div`
+    margin-top: 30px;
+    font-size: 20px;
+    margin-bottom: 80px;
+`;
+
+export const StartButton = styled.div`
+    background-color: #0a84ff;
+    padding: 15px;
+    width: 230px;
+    color: white;
+    font-weight: bold;
+    font-size: 20px;
+    border-radius: 20px;
+    margin-bottom: 25px;
+`;
+
+export const Login = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    color: #616161;
+    gap: 10px;
+`;
+
+export const LoginButton = styled.div`
+    color: #0a84ff;
+    font-weight: bold;
+`;


### PR DESCRIPTION
# [feature/onboarding] 온보딩 페이지 및 스타일 추가

## PR요약

해당 pr은
-   온보딩 화면을 추가하고, 사용자에게 서비스 시작을 유도하는 기본 화면을 구성했습니다.
-   "시작하기" 버튼 클릭 시 회원가입 페이지로 이동할 수 있도록 라우팅을 연결했습니다.

## 관련 이슈

없음

## 작업 내용

-   온보딩 페이지(`Onboarding.jsx`) 추가
    -   WIDER 로고와 소개 문구, 시작하기 버튼, 로그인 버튼 추가
-   온보딩 스타일 파일(`OnboardingStyles.jsx`) 추가
    -   페이지 중앙 정렬 및 각 요소들의 스타일링 적용
-   버튼 클릭 시 회원가입(`/signup`) 페이지로 이동하도록 라우터 연결

## 공유사항

-   로그인 버튼은 현재 클릭 이벤트가 연결되어 있지 않습니다. 추후 로그인 페이지 추가 후 연동 필요합니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
