### PR TITLE
[feat] 온보딩 페이지에 로그인 페이지 이동 기능 및 스타일 추가

### DIFF
--- a/src/pages/intro/Onboarding.jsx
+++ b/src/pages/intro/Onboarding.jsx
@@ -10,6 +10,10 @@ const Onboarding = () => {
         navigate('/signup');
     };
 
+    const goToLogin = () => {
+        navigate('/login');
+    };
+
     return (
         <On.Container>
             <On.LogoImg>
@@ -22,9 +26,10 @@ const Onboarding = () => {
             <On.StartButton onClick={goToSignUp}>시작하기</On.StartButton>
             <On.Login>
                 이미 계정이 있으신가요?
-                <On.LoginButton>로그인</On.LoginButton>
+                <On.LoginButton onClick={goToLogin}>로그인</On.LoginButton>
             </On.Login>
         </On.Container>
     );
 };
+
 export default Onboarding;

--- a/src/pages/intro/OnboardingStyles.jsx
+++ b/src/pages/intro/OnboardingStyles.jsx
@@ -38,6 +38,7 @@ export const StartButton = styled.div`
     font-size: 20px;
     border-radius: 20px;
     margin-bottom: 25px;
+    cursor: pointer;
 `;
 
 export const Login = styled.div`
@@ -52,4 +53,5 @@ export const Login = styled.div`
 export const LoginButton = styled.div`
     color: #0a84ff;
     font-weight: bold;
+    cursor: pointer;
 `;


### PR DESCRIPTION
# [feature/onboarding] 온보딩 페이지에 로그인 페이지 이동 기능 및 스타일 추가

## PR요약

해당 pr은
-   온보딩 페이지에 로그인 페이지로 이동할 수 있는 네비게이션 기능을 추가했습니다.
-   버튼의 스타일을 사용자 친화적으로 개선했습니다.

## 관련 이슈

없음

## 작업 내용

-   `Onboarding.jsx`에서 로그인 페이지(`/login`)로 이동할 수 있도록 버튼에 `useNavigate` 로직 추가
-   `OnboardingStyles.jsx`에 로그인 버튼 커서 포인터 적용

## 공유사항

-   로고 이미지 및 전체 구조가 다른 페이지와 일관되도록 유지되고 있는지 확인 필요

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
