### PR TITLE
[feat] 회원가입 페이지에 온보딩 페이지 이동 기능 추가

### DIFF
--- a/src/pages/signup/SignUp.jsx
+++ b/src/pages/signup/SignUp.jsx
@@ -1,9 +1,15 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as Su from './SignUpStyles.jsx';
 import AuthHeader from '../../components/header/AuthHeader';
-
 const SignUp = () => {
     const [gender, setGender] = useState(null);
+
+    const navigate = useNavigate();
+
+    const goToOnboarding = () => {
+        navigate('/onboarding');
+    };
 
     return (
         <Su.Container>
@@ -24,9 +30,10 @@ const SignUp = () => {
                 <Su.Input type="text" placeholder="hellowider25" />
                 <Su.Text>비밀번호</Su.Text>
                 <Su.Input type="password" placeholder="비밀번호를 입력하세요" />
-                <Su.StartButton>WIDER 시작하기</Su.StartButton>
+                <Su.StartButton onClick={goToOnboarding}>WIDER 시작하기</Su.StartButton>
             </Su.Content>
         </Su.Container>
     );
 };
+
 export default SignUp;


### PR DESCRIPTION
# [feature/signup] 회원가입 페이지에 온보딩 페이지 이동 기능 추가

## PR요약

해당 pr은
-   회원가입 완료 시 온보딩 페이지(/onboarding)로 이동하는 기능을 추가했습니다.
-   사용자 흐름(회원가입 → 온보딩)을 구현하기 위한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `SignUp.jsx`에 `useNavigate` 훅을 사용하여 온보딩 페이지로의 이동 기능 추가
-   `WIDER 시작하기` 버튼 클릭 시 `/onboarding` 경로로 이동되도록 처리

## 공유사항

-   회원가입 입력값 유효성 검사 및 API 연동은 추후 작업 예정입니다.
-   현재는 UI 흐름 확인을 위한 기능 구현에 집중했습니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
