### PR TITLE
[feat] 채팅 모바일 페이지(ChatScreen) 및 스타일(ChatScreenStyles) 파일 추가

### DIFF
--- a/src/pages/chat/ChatScreen.jsx
+++ b/src/pages/chat/ChatScreen.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Cs from './ChatScreenStyles.jsx';
+import ArrowLeft from '../../assets/ArrowLeft.png';
+import LogoIcon from '../../assets/LogoIcon.png';
+import Report from '../../assets/Report.png';
+import Send from '../../assets/Send.png';
+
+const Chat = () => {
+    const navigate = useNavigate();
+
+    const goToReport = () => {
+        navigate('/report');
+    };
+
+    return (
+        <Cs.Container>
+            <Cs.Header>
+                <Cs.ArrowLeft onClick={() => navigate(-1)}>
+                    <img src={ArrowLeft} />
+                </Cs.ArrowLeft>
+                <Cs.LogoIcon>
+                    <img src={LogoIcon} />
+                </Cs.LogoIcon>
+                <Cs.HeaderText>
+                    <Cs.ServiceName>WIDER</Cs.ServiceName>
+                    <Cs.ServiceTagline>내 생각을 키워주는 AI 파트너</Cs.ServiceTagline>
+                </Cs.HeaderText>
+                <Cs.Report onClick={goToReport}>
+                    <img src={Report} />
+                </Cs.Report>
+            </Cs.Header>
+            <Cs.Content>
+                <Cs.Date>2025/03/25</Cs.Date>
+                <Cs.Chat>
+                    <Cs.Chatbot>기본 소득이란 무엇일까?</Cs.Chatbot>
+                    <Cs.ChatUser>
+                        음... 아무 일도 하지 않아도 모든 사람에게 일정한 돈을 주는 제도인 것 같아.
+                    </Cs.ChatUser>
+                </Cs.Chat>
+            </Cs.Content>
+            <Cs.InputBox>
+                <Cs.InputWrapper>
+                    <Cs.Input type="text" />
+                    <Cs.Send>
+                        <img src={Send} />
+                    </Cs.Send>
+                </Cs.InputWrapper>
+            </Cs.InputBox>
+        </Cs.Container>
+    );
+};
+export default Chat;

--- a/src/pages/chat/ChatScreenStyles.jsx
+++ b/src/pages/chat/ChatScreenStyles.jsx
@@ -1,0 +1,161 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    min-height: 100vh;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background-color: #f9f9f9;
+`;
+
+export const Header = styled.div`
+    background-color: #d8eaff;
+    position: fixed;
+    top: 0;
+    width: 393px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 20px;
+`;
+
+export const ArrowLeft = styled.div`
+    img {
+        width: 30px;
+        height: 30px;
+    }
+    margin-left: 20px;
+`;
+
+export const LogoIcon = styled.div`
+    img {
+        width: 60px;
+        height: 50px;
+    }
+    margin-left: -5px;
+`;
+
+export const HeaderText = styled.div`
+    margin-right: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+    margin-left: -8px;
+`;
+
+export const ServiceName = styled.div`
+    font-size: 20px;
+`;
+
+export const ServiceTagline = styled.div`
+    font-size: 12px;
+`;
+
+export const Report = styled.div`
+    img {
+        width: 50px;
+        height: 50px;
+    }
+    margin-right: 20px;
+    cursor: pointer;
+`;
+
+export const Content = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    margin-top: -100%;
+`;
+
+export const Date = styled.div`
+    position: fixed;
+    top: 90px;
+    width: 393px;
+    display: flex;
+    justify-content: center;
+    text-align: center;
+    font-size: 16px;
+    font-weight: bold;
+    padding: 10px 0;
+    z-index: 1;
+`;
+
+export const Chat = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    padding: 0 20px;
+    margin-top: 20%;
+`;
+
+export const Chatbot = styled.div`
+    align-self: flex-start;
+    background-color: #f5f5f5;
+    padding: 14px 18px;
+    border-radius: 20px;
+    font-size: 14px;
+    text-align: center;
+    width: 70%;
+    line-height: 1.6;
+    max-width: 70%;
+    min-height: 50px;
+`;
+
+export const ChatUser = styled.div`
+    align-self: flex-end;
+    background-color: #d8f2ff;
+    padding: 14px 18px;
+    border-radius: 20px;
+    font-size: 14px;
+    text-align: center;
+    width: 70%;
+    line-height: 1.6;
+    max-width: 70%;
+    min-height: 50px;
+`;
+
+export const InputBox = styled.div`
+    position: fixed;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    padding: 35px;
+    z-index: 2;
+`;
+
+export const InputWrapper = styled.div`
+    position: relative;
+    width: 100%;
+`;
+
+export const Input = styled.input`
+    padding: 0px 180px 0px 20px;
+    border-radius: 20px;
+    border: 1px solid #000000;
+    font-size: 14px;
+    outline: none;
+    height: 45px;
+    box-sizing: border-box;
+`;
+
+export const Send = styled.div`
+    position: absolute;
+    top: 25%;
+    right: 15px;
+    cursor: pointer;
+    img {
+        width: 23px;
+        height: 23px;
+    }
+`;


### PR DESCRIPTION
# [feature/chat] 채팅 모바일 페이지(ChatScreen) 및 스타일(ChatScreenStyles) 파일 추가

## PR요약

해당 pr은

-   `/chat` 경로에 대응하는 모바일 전용 채팅 페이지(ChatScreen)와 스타일 파일(ChatScreenStyles.jsx)을 추가했습니다.
-   채팅 UI 초기 레이아웃 구성을 완료하여 이후 기능 연동 작업의 기반을 마련했습니다.

## 관련 이슈

없음

## 작업 내용

-   채팅 모바일 화면 컴포넌트 `ChatScreen.jsx` 추가
    -   Header, Content, Input 영역으로 구성
    -   뒤로가기 버튼, 로고, Report 이동 버튼 포함
-   스타일 파일 `ChatScreenStyles.jsx` 작성
    -   전체적인 모바일 뷰 기준 393px 레이아웃
    -   고정된 헤더/날짜/입력창 영역 및 말풍선 정렬 구현

## 공유사항

-   Header 내부 레이아웃 간격이나 margin 값은 추후 피드백 반영 예정입니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
