### PR TITLE
[feat] 사이드바에서 /report 경로에서도 Chat 탭 on 상태 유지 기능 추가

### DIFF
--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import * as S from './SidebarStyles.jsx';
+import ChatOn from '../../assets/ChatOn.svg';
+import ChatOff from '../../assets/ChatOff.svg';
+import HomeOn from '../../assets/HomeDeskOn.svg';
+import HomeOff from '../../assets/HomeDeskOff.svg';
+import RecordOn from '../../assets/RecordDeskOn.svg';
+import RecordOff from '../../assets/RecordDeskOff.svg';
+import InsightOn from '../../assets/InsightDeskOn.svg';
+import InsightOff from '../../assets/InsightDeskOff.svg';
+import SettingOn from '../../assets/SettingDeskOn.svg';
+import SettingOff from '../../assets/SettingDeskOff.svg';
+
+const Sidebar = () => {
+    const location = useLocation();
+
+    const navigate = useNavigate();
+
+    const goToChat = () => {
+        navigate('/chat');
+    };
+
+    const goToHome = () => {
+        navigate('/home');
+    };
+
+    const goToRecord = () => {
+        navigate('/recordsdesk');
+    };
+
+    const goToInsight = () => {
+        navigate('/insightdesk');
+    };
+
+    const goToSetting = () => {
+        navigate('/settingdesk');
+    };
+
+    return (
+        <S.Container>
+            <S.TopNav>
+                <S.Chat onClick={goToChat}>
+                    <img src={location.pathname === '/chat' || location.pathname === '/report' ? ChatOn : ChatOff} />
+                </S.Chat>
+                <S.Home onClick={goToHome}>
+                    <img src={location.pathname === '/home' ? HomeOn : HomeOff} />
+                </S.Home>
+                <S.Record onClick={goToRecord}>
+                    <img src={location.pathname === '/recordsdesk' ? RecordOn : RecordOff} />
+                </S.Record>
+                <S.Insight onClick={goToInsight}>
+                    <img src={location.pathname === '/insightdesk' ? InsightOn : InsightOff} />
+                </S.Insight>
+            </S.TopNav>
+            <S.BottomNav>
+                <S.Setting onClick={goToSetting}>
+                    <img src={location.pathname === '/setting' ? SettingOn : SettingOff} />
+                </S.Setting>
+            </S.BottomNav>
+        </S.Container>
+    );
+};
+export default Sidebar;

--- a/src/components/sidebar/SidebarStyles.jsx
+++ b/src/components/sidebar/SidebarStyles.jsx
@@ -1,0 +1,67 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 130px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+    background-color: #f9f9f9;
+    z-index: 10;
+`;
+
+export const TopNav = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 0px;
+`;
+
+export const BottomNav = styled.div`
+    margin-top: 220px;
+`;
+
+export const Chat = styled.div`
+    img {
+        width: 85px;
+        height: 85px;
+    }
+    cursor: pointer;
+`;
+
+export const Home = styled.div`
+    img {
+        width: 85px;
+        height: 85px;
+    }
+    cursor: pointer;
+`;
+
+export const Record = styled.div`
+    img {
+        width: 85px;
+        height: 85px;
+    }
+    cursor: pointer;
+`;
+
+export const Insight = styled.div`
+    img {
+        width: 85px;
+        height: 85px;
+    }
+    cursor: pointer;
+`;
+
+export const Setting = styled.div`
+    img {
+        width: 85px;
+        height: 85px;
+    }
+    cursor: pointer;
+`;


### PR DESCRIPTION
# [feature/report] 사이드바에서 /report 경로에서도 Chat 탭 on 상태 유지 기능 추가

## PR요약

해당 pr은
-   사이드바에서 `/report` 경로일 때도 Chat 탭이 활성화(on) 상태로 유지되도록 기능을 수정했습니다.
-   기존에는 `/chat` 경로에서만 on 상태가 되었기 때문에 이를 수정했습니다.

## 관련 이슈

없음

## 작업 내용

-   사이드바의 `Chat` 탭 이미지 렌더 조건을
`location.pathname === '/chat'` 
→ `location.pathname === '/chat' || location.pathname === '/report'`로 수정해서 `/report` 경로에서도 활성화된 아이콘(ChatOn)이 적용되도록 개선했습니다.

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
