### PR TITLE
[feat] 반응형 홈페이지 구현 (ChatPage.jsx, ReportPage.jsx)

### DIFF
--- a/src/pages/chat/ChatPage.jsx
+++ b/src/pages/chat/ChatPage.jsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+import ChatMobile from './ChatScreen';
+import ChatDesktop from './ChatDeskScreen';
+
+const ChatPage = () => {
+    const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth <= 768);
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return isMobile ? <ChatMobile /> : <ChatDesktop />;
+};
+
+export default ChatPage;

--- a/src/pages/report/ReportPage.jsx
+++ b/src/pages/report/ReportPage.jsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+import ReportMobile from './ReportScreen';
+import ReportDesktop from './ReportDeskScreen';
+
+const ReportPage = () => {
+    const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setIsMobile(window.innerWidth <= 768);
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return isMobile ? <ReportMobile /> : <ReportDesktop />;
+};
+
+export default ReportPage;


### PR DESCRIPTION
# [feature/responsive] 반응형 홈페이지 구현 (ChatPage.jsx, ReportPage.jsx)

## PR요약

해당 pr은
-   `/chat`과 `/report` 경로에 대해 뷰포트 너비에 따라 모바일/데스크탑 컴포넌트를 자동으로 분기 렌더링하는 반응형 구조를 구현했습니다.

## 관련 이슈

없음

## 작업 내용

-   `ChatPage.jsx`와 `ReportPage.jsx`를 새로 생성하여 뷰포트 기준으로 모바일(`width <= 768px`)과 데스크탑 컴포넌트를 조건부 렌더링하도록 구현
-   `useEffect`와 `resize` 이벤트를 활용하여 실시간 반응형 전환 처리
-   구조적으로 `Router`에서 단일 경로 (`/chat`, `/report`)를 유지하면서 반응형 페이지를 지원
```jsx
return isMobile ? <ChatMobile /> : <ChatDesktop />;
```
-   페이지 구조가 명확하게 나뉘어 유지보수성과 확장성 개선

## 공유사항

-   향후 다른 페이지에도 동일한 방식의 반응형 처리 방식 적용 가능

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
