### PR TITLE
[feat] 오늘의 질문 클릭 시 채팅 화면으로 이동 기능 추가 (HomeScreen, HomeDeskScreen)

### DIFF
--- a/src/pages/home/HomeDeskScreen.jsx
+++ b/src/pages/home/HomeDeskScreen.jsx
@@ -1,16 +1,22 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as Hd from './HomeDeskScreenStyles.jsx';
-import LogoIcon from '../../assets/LogoIcon.png';
 import HomeDeskHeader from '../../components/header/HomeDeskHeader';
 import Sidebar from '../../components/sidebar/Sidebar';
 
-const Home = () => {
+const HomeDesk = () => {
+    const navigate = useNavigate();
+
+    const goToChat = () => {
+        navigate('/chat');
+    };
+
     return (
         <Hd.Container>
             <HomeDeskHeader />
             <Hd.Content>
                 <Hd.Title>오늘의 질문</Hd.Title>
-                <Hd.Question>기본 소득 도입 정책에 대해서 어떻게 생각하세요?</Hd.Question>
+                <Hd.Question onClick={goToChat}>기본 소득 도입 정책에 대해서 어떻게 생각하세요?</Hd.Question>
                 <Hd.StartConversation>터치하여 대화를 시작하세요!</Hd.StartConversation>
                 <Hd.ReportCreated>어제의 리포트가 생성되었습니다!</Hd.ReportCreated>
                 <Hd.ButtonReport>리포트 보러 가기</Hd.ButtonReport>
@@ -19,4 +25,4 @@ const Home = () => {
         </Hd.Container>
     );
 };
-export default Home;
+export default HomeDesk;

--- a/src/pages/home/HomeScreen.jsx
+++ b/src/pages/home/HomeScreen.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as H from './HomeScreenStyles.jsx';
 import LogoIcon from '../../assets/LogoIcon.png';
 import BellOff from '../../assets/BellOff.png';
@@ -6,6 +7,12 @@ import BellOff from '../../assets/BellOff.png';
 import Footer from '../../components/footer/Footer';
 
 const Home = () => {
+    const navigate = useNavigate();
+
+    const goToChat = () => {
+        navigate('/chat');
+    };
+
     return (
         <H.Container>
             <H.Header>
@@ -22,7 +29,7 @@ const Home = () => {
             </H.Header>
             <H.Content>
                 <H.Title>오늘의 질문</H.Title>
-                <H.Question>기본 소득 도입 정책에 대해서 어떻게 생각하세요?</H.Question>
+                <H.Question onClick={goToChat}>기본 소득 도입 정책에 대해서 어떻게 생각하세요?</H.Question>
                 <H.StartConversation>
                     터치하여 대화를 <br />
                     시작하세요!


### PR DESCRIPTION
# [feature/home] 오늘의 질문 클릭 시 채팅 화면으로 이동 기능 추가 (HomeScreen, HomeDeskScreen)

## PR요약

해당 pr은
-   메인 홈 화면에서 "오늘의 질문"을 클릭하면 채팅 화면(`/chat`)으로 이동하는 기능을 추가한 작업입니다.
-   사용자 흐름 상 자연스럽게 대화를 시작할 수 있도록 인터랙션을 개선했습니다.

## 관련 이슈

없음

## 작업 내용

-   HomeScreen.jsx (모바일): `onClick` 이벤트를 통해 `/chat` 경로로 이동하도록 구현
-   HomeDeskScreen.jsx (데스크탑): 동일한 기능 추가
-   공통적으로 `useNavigate()` 훅을 활용하여 페이지 전환 구현

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
