### PR TITLE
[feat] 푸터 아이콘 svg로 교체 및 경로별 조건부 렌더링 적용

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import * as F from './FooterStyles.jsx';
-import RecordOff from '../../assets/RecordOff.png';
-import RecordOn from '../../assets/RecordOn.png';
-import HomeOff from '../../assets/HomeOff.png';
-import HomeOn from '../../assets/HomeOn.png';
-import InsightOff from '../../assets/InsightOff.png';
-import InsightOn from '../../assets/InsightOn.png';
+import RecordOff from '../../assets/RecordOff.svg';
+import RecordOn from '../../assets/RecordOn.svg';
+import HomeOff from '../../assets/HomeOff.svg';
+import HomeOn from '../../assets/HomeOn.svg';
+import InsightOff from '../../assets/InsightOff.svg';
+import InsightOn from '../../assets/InsightOn.svg';
 
 const Footer = () => {
     const location = useLocation();
@@ -15,7 +15,7 @@ const Footer = () => {
     const navigate = useNavigate();
 
     const goToRecord = () => {
-        navigate('/record');
+        navigate('/recordcategory');
     };
 
     const goToHome = () => {
@@ -30,7 +30,13 @@ const Footer = () => {
         <F.Container>
             <F.Record onClick={goToRecord}>
                 <F.RecordImg>
-                    <img src={location.pathname === '/records' ? RecordOn : RecordOff} />
+                    <img
+                        src={
+                            location.pathname === '/recordcategory' || location.pathname === '/recorddate'
+                                ? RecordOn
+                                : RecordOff
+                        }
+                    />
                 </F.RecordImg>
                 <F.RecordText isActive={location.pathname === '/records'}>records</F.RecordText>
             </F.Record>
@@ -42,7 +48,13 @@ const Footer = () => {
             </F.Home>
             <F.Insight onClick={goToInsight}>
                 <F.InsightImg>
-                    <img src={location.pathname === '/insight' ? InsightOn : InsightOff} />
+                    <img
+                        src={
+                            location.pathname === '/insight' || location.pathname === '/insightchart'
+                                ? InsightOn
+                                : InsightOff
+                        }
+                    />
                 </F.InsightImg>
                 <F.InsightText isActive={location.pathname === '/insight'}>insight</F.InsightText>
             </F.Insight>

--- a/src/components/footer/FooterStyles.jsx
+++ b/src/components/footer/FooterStyles.jsx
@@ -12,8 +12,8 @@ export const Container = styled.div`
     justify-content: space-around;
     align-items: center;
     text-align: center;
-    background-color: #eeebeb;
-    z-index: 10;
+    background-color: #eeecec;
+    z-index: 100;
     gap: 20px;
 `;
 
@@ -33,7 +33,7 @@ export const RecordImg = styled.div`
 `;
 
 export const RecordText = styled.div`
-    color: ${({ isActive }) => (isActive ? '#0A84FF' : '#ada7a7')};
+    color: ${({ isActive }) => (isActive ? '#6BA9EC' : '#ada7a7')};
     font-size: 16px;
 `;
 
@@ -54,7 +54,7 @@ export const HomeImg = styled.div`
 `;
 
 export const HomeText = styled.div`
-    color: ${({ isActive }) => (isActive ? '#0A84FF' : '#ada7a7')};
+    color: ${({ isActive }) => (isActive ? '#6BA9EC' : '#ada7a7')};
     font-size: 16px;
 `;
 
@@ -74,6 +74,6 @@ export const InsightImg = styled.div`
 `;
 
 export const InsightText = styled.div`
-    color: ${({ isActive }) => (isActive ? '#0A84FF' : '#ada7a7')};
+    color: ${({ isActive }) => (isActive ? '#6BA9EC' : '#ada7a7')};
     font-size: 16px;
 `;


### PR DESCRIPTION
# [feature/footer] 푸터 아이콘 svg로 교체 및 경로별 조건부 렌더링 적용

## PR요약

해당 pr은
-   푸터(Footer) 영역의 아이콘을 기존 PNG에서 SVG로 교체했습니다.
-   현재 라우트 경로에 따라 아이콘 색상 및 텍스트 스타일이 동적으로 변경되도록 조건부 렌더링을 적용한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   푸터 아이콘 이미지 파일을 SVG 포맷으로 변경
    -   이유: SVG는 해상도에 독립적이기 때문에 다양한 화면에서도 선명하게 표시 가능
-   현재 라우트에 따라 아이콘 및 텍스트 색상이 변경되도록 조건부 렌더링 로직 추가
    -   개선점: 사용자에게 현재 위치를 명확히 인지시키는 UI 제공
-   관련 스타일 코드(`FooterStyles.jsx`) 수정 및 최적화

## 공유사항

-   `location.pathname`을 기준으로 경로 판단을 하고 있어, 라우트가 `/recorddate`등의 세부 경로일 경우도 고려하여 조건을 작성했습니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
