### PR TITLE
[feat] 기록 목록 카테고리 및 날짜별 페이지 모바일/데스크탑 구현

### DIFF
--- a/src/pages/chatRecord/RecordCategory.jsx
+++ b/src/pages/chatRecord/RecordCategory.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Rc from './RecordCategoryStyles.jsx';
+import Header from '../../components/header/SettingsHeader';
+import Footer from '../../components/footer/Footer';
+
+const RecordCategory = () => {
+    const navigate = useNavigate();
+
+    const goToRecordDate = () => {
+        navigate('/recorddate');
+    };
+
+    return (
+        <Rc.Container>
+            <Header />
+            <Rc.Category>
+                <Rc.Content onClick={goToRecordDate}>
+                    <Rc.CategoryName>사회</Rc.CategoryName>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025
+                            <br />
+                            03/25
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>공휴일 확대가 국가 경제에 도움이 될까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025 <br />
+                            03/23
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>주 4일제 근무에 대해 어떻게 생각하세요?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                </Rc.Content>
+                <Rc.Content onClick={goToRecordDate}>
+                    <Rc.CategoryName>과학</Rc.CategoryName>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025
+                            <br />
+                            03/24
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>AI는 정말로 사람의 일자리를 뺏을까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025 <br />
+                            03/22
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>딥시크 사태는 글로벌 AI 산업에 어떤 영향을 미쳤을까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                </Rc.Content>
+                <Rc.Content onClick={goToRecordDate}>
+                    <Rc.CategoryName>정치</Rc.CategoryName>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025
+                            <br />
+                            03/21
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>청년 정치인의 참여 확대는 어떤 변화를 가져올 수 있을까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025 <br />
+                            03/18
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>대통령 임기 단축 또는 연장, 어느 쪽이 더 바람직할까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                </Rc.Content>
+                <Rc.Content onClick={goToRecordDate}>
+                    <Rc.CategoryName>경제</Rc.CategoryName>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025
+                            <br />
+                            03/20
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>기본소득 제도는 경제 성장에 도움이 될까, 저해가 될까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025 <br />
+                            03/17
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>플랫폼 노동(배달, 택시 등)은 지속 가능한 일자리일까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                </Rc.Content>
+                <Rc.Content onClick={goToRecordDate}>
+                    <Rc.CategoryName>세계</Rc.CategoryName>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025
+                            <br />
+                            03/19
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>세계화는 각국의 문화를 풍요롭게 할까, 파괴할까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                    <Rc.CategoryContent>
+                        <Rc.CategoryDate>
+                            2025 <br />
+                            03/16
+                        </Rc.CategoryDate>
+                        <Rc.ContentTitle>난민 수용에 대한 국제 사회의 역할은 어디까지여야 할까?</Rc.ContentTitle>
+                    </Rc.CategoryContent>
+                </Rc.Content>
+            </Rc.Category>
+            <Footer />
+        </Rc.Container>
+    );
+};
+export default RecordCategory;

--- a/src/pages/chatRecord/RecordCategoryDesk.jsx
+++ b/src/pages/chatRecord/RecordCategoryDesk.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Rd from './RecordCategoryDeskStyles.jsx';
+import HomeDeskHeader from '../../components/header/HomeDeskHeader';
+import Sidebar from '../../components/sidebar/Sidebar';
+
+const RecordCategoryDesk = () => {
+    const navigate = useNavigate();
+
+    const goToRecordDate = () => {
+        navigate('/recorddate');
+    };
+
+    return (
+        <Rd.Container>
+            <HomeDeskHeader />
+            <Rd.Category>
+                <Rd.Content onClick={goToRecordDate}>
+                    <Rd.CategoryName>사회</Rd.CategoryName>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025
+                            <br />
+                            03/25
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>공휴일 확대가 국가 경제에 도움이 될까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025 <br />
+                            03/23
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>주 4일제 근무에 대해 어떻게 생각하세요?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                </Rd.Content>
+                <Rd.Content onClick={goToRecordDate}>
+                    <Rd.CategoryName>과학</Rd.CategoryName>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025
+                            <br />
+                            03/24
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>AI는 정말로 사람의 일자리를 뺏을까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025 <br />
+                            03/22
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>딥시크 사태는 글로벌 AI 산업에 어떤 영향을 미쳤을까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                </Rd.Content>
+                <Rd.Content onClick={goToRecordDate}>
+                    <Rd.CategoryName>정치</Rd.CategoryName>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025
+                            <br />
+                            03/21
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>청년 정치인의 참여 확대는 어떤 변화를 가져올 수 있을까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025 <br />
+                            03/18
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>대통령 임기 단축 또는 연장, 어느 쪽이 더 바람직할까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                </Rd.Content>
+                <Rd.Content onClick={goToRecordDate}>
+                    <Rd.CategoryName>경제</Rd.CategoryName>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025
+                            <br />
+                            03/20
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>기본소득 제도는 경제 성장에 도움이 될까, 저해가 될까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025 <br />
+                            03/17
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>플랫폼 노동(배달, 택시 등)은 지속 가능한 일자리일까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                </Rd.Content>
+                <Rd.Content onClick={goToRecordDate}>
+                    <Rd.CategoryName>세계</Rd.CategoryName>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025
+                            <br />
+                            03/19
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>세계화는 각국의 문화를 풍요롭게 할까, 파괴할까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                    <Rd.CategoryContent>
+                        <Rd.CategoryDate>
+                            2025 <br />
+                            03/16
+                        </Rd.CategoryDate>
+                        <Rd.ContentTitle>난민 수용에 대한 국제 사회의 역할은 어디까지여야 할까?</Rd.ContentTitle>
+                    </Rd.CategoryContent>
+                </Rd.Content>
+            </Rd.Category>
+            <Sidebar />
+        </Rd.Container>
+    );
+};
+export default RecordCategoryDesk;

--- a/src/pages/chatRecord/RecordCategoryDeskStyles.jsx
+++ b/src/pages/chatRecord/RecordCategoryDeskStyles.jsx
@@ -1,0 +1,72 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    width: 90%;
+    margin: 0 auto;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin-top: 80px;
+    margin-left: 130px;
+`;
+
+export const Category = styled.div`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow-y: auto;
+    padding: 40px;
+    width: 100%;
+    box-sizing: border-box;
+    padding-bottom: 130px;
+    min-height: 200px;
+    height: 500px;
+`;
+
+export const Content = styled.div`
+    margin-top: 5%;
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+    background-color: #f8f8f8;
+    border-radius: 20px;
+    padding: 40px;
+    cursor: pointer;
+`;
+
+export const CategoryName = styled.div`
+    font-weight: bold;
+    font-size: 18px;
+    color: #383636;
+    margin-bottom: -10px;
+    align-self: flex-start;
+    margin-left: 10px;
+`;
+
+export const CategoryContent = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: #e6e4e4;
+    border-radius: 20px;
+    padding: 20px 15px;
+    color: #383636;
+    font-weight: bold;
+`;
+
+export const CategoryDate = styled.div`
+    font-size: 16px;
+    margin-right: 20px;
+    white-space: nowrap;
+`;
+
+export const ContentTitle = styled.div`
+    font-size: 16px;
+    text-align: left;
+    word-break: keep-all;
+`;

--- a/src/pages/chatRecord/RecordCategoryStyles.jsx
+++ b/src/pages/chatRecord/RecordCategoryStyles.jsx
@@ -1,0 +1,71 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+`;
+
+export const Category = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    width: 100%;
+    box-sizing: border-box;
+    padding-bottom: 130px;
+    min-height: 200px;
+    height: 500px;
+    margin-top: 20%;
+`;
+
+export const Content = styled.div`
+    margin-top: 0px;
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+    background-color: #f8f8f8;
+    border-radius: 20px;
+    padding: 15px;
+    cursor: pointer;
+`;
+
+export const CategoryName = styled.div`
+    font-weight: bold;
+    font-size: 18px;
+    color: #383636;
+    margin-bottom: -10px;
+    align-self: flex-start;
+    margin-left: 10px;
+`;
+
+export const CategoryContent = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: #e6e4e4;
+    border-radius: 20px;
+    padding: 20px 15px;
+    color: #383636;
+    font-weight: bold;
+`;
+
+export const CategoryDate = styled.div`
+    font-size: 16px;
+    margin-right: 10px;
+    white-space: nowrap;
+`;
+
+export const ContentTitle = styled.div`
+    font-size: 16px;
+    text-align: left;
+    word-break: keep-all;
+`;

--- a/src/pages/chatRecord/RecordDate.jsx
+++ b/src/pages/chatRecord/RecordDate.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Rd from './RecordDateStyles.jsx';
+import Header from '../../components/header/SettingsHeader';
+import Footer from '../../components/footer/Footer';
+
+const RecordDate = () => {
+    const navigate = useNavigate();
+
+    return (
+        <Rd.Container>
+            <Header />
+            <Rd.Content>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025
+                        <br />
+                        03/25
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>공휴일 확대가 국가 경제에 도움이 될까?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025 <br />
+                        03/24
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>주 4일제 근무에 대해 어떻게 생각하세요?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025 <br />
+                        03/23
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>AI는 정말로 사람의 일자리를 뺏을까?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025 <br />
+                        03/22
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>딥시크 사태는 글로벌 AI 산업에 어떤 영향을 미쳤을까?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025 <br />
+                        03/21
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>인공지능의 발전이 교육 방식에 어떤 변화를 가져올까?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025 <br />
+                        03/20
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>디지털 기술이 인간관계에 미치는 영향은 긍정적일까?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+                <Rd.CategoryContent>
+                    <Rd.CategoryDate>
+                        2025 <br />
+                        03/19
+                    </Rd.CategoryDate>
+                    <Rd.ContentTitle>청년층의 정치 참여를 높이기 위한 방안은 무엇일까?</Rd.ContentTitle>
+                </Rd.CategoryContent>
+            </Rd.Content>
+            <Footer />
+        </Rd.Container>
+    );
+};
+export default RecordDate;

--- a/src/pages/chatRecord/RecordDateDesk.jsx
+++ b/src/pages/chatRecord/RecordDateDesk.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as R from './RecordDateDeskStyles.jsx';
+import HomeDeskHeader from '../../components/header/HomeDeskHeader';
+import Sidebar from '../../components/sidebar/Sidebar';
+
+const RecordDate = () => {
+    const navigate = useNavigate();
+
+    return (
+        <R.Container>
+            <HomeDeskHeader />
+            <R.Content>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025
+                        <br />
+                        03/25
+                    </R.CategoryDate>
+                    <R.ContentTitle>공휴일 확대가 국가 경제에 도움이 될까?</R.ContentTitle>
+                </R.CategoryContent>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025 <br />
+                        03/24
+                    </R.CategoryDate>
+                    <R.ContentTitle>주 4일제 근무에 대해 어떻게 생각하세요?</R.ContentTitle>
+                </R.CategoryContent>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025 <br />
+                        03/23
+                    </R.CategoryDate>
+                    <R.ContentTitle>AI는 정말로 사람의 일자리를 뺏을까?</R.ContentTitle>
+                </R.CategoryContent>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025 <br />
+                        03/22
+                    </R.CategoryDate>
+                    <R.ContentTitle>딥시크 사태는 글로벌 AI 산업에 어떤 영향을 미쳤을까?</R.ContentTitle>
+                </R.CategoryContent>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025 <br />
+                        03/21
+                    </R.CategoryDate>
+                    <R.ContentTitle>인공지능의 발전이 교육 방식에 어떤 변화를 가져올까?</R.ContentTitle>
+                </R.CategoryContent>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025 <br />
+                        03/20
+                    </R.CategoryDate>
+                    <R.ContentTitle>디지털 기술이 인간관계에 미치는 영향은 긍정적일까?</R.ContentTitle>
+                </R.CategoryContent>
+                <R.CategoryContent>
+                    <R.CategoryDate>
+                        2025 <br />
+                        03/19
+                    </R.CategoryDate>
+                    <R.ContentTitle>청년층의 정치 참여를 높이기 위한 방안은 무엇일까?</R.ContentTitle>
+                </R.CategoryContent>
+            </R.Content>
+            <Sidebar />
+        </R.Container>
+    );
+};
+export default RecordDate;

--- a/src/pages/chatRecord/RecordDateDeskStyles.jsx
+++ b/src/pages/chatRecord/RecordDateDeskStyles.jsx
@@ -1,0 +1,50 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    width: 90%;
+    margin: 0 auto;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin-top: 100px;
+    margin-left: 130px;
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    width: 90%;
+    margin-top: 0px;
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+    border-radius: 20px;
+    padding: 50px 15px 100px;
+`;
+export const CategoryContent = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: #e6e4e4;
+    border-radius: 20px;
+    padding: 20px 15px;
+    color: #383636;
+    font-weight: bold;
+`;
+
+export const CategoryDate = styled.div`
+    font-size: 16px;
+    margin-right: 10px;
+    white-space: nowrap;
+`;
+
+export const ContentTitle = styled.div`
+    font-size: 16px;
+    text-align: left;
+    word-break: keep-all;
+`;

--- a/src/pages/chatRecord/RecordDateStyles.jsx
+++ b/src/pages/chatRecord/RecordDateStyles.jsx
@@ -1,0 +1,51 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    min-height: 100vh;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background-color: #ffffff;
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    margin-top: 0px;
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+    border-radius: 20px;
+    /* padding: 15px; */
+    padding: 100px 15px 130px;
+`;
+export const CategoryContent = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: #e6e4e4;
+    border-radius: 20px;
+    padding: 20px 15px;
+    color: #383636;
+    font-weight: bold;
+`;
+
+export const CategoryDate = styled.div`
+    font-size: 16px;
+    margin-right: 10px;
+    white-space: nowrap;
+`;
+
+export const ContentTitle = styled.div`
+    font-size: 16px;
+    text-align: left;
+    word-break: keep-all;
+`;


### PR DESCRIPTION
# [feature/record] 기록 목록 카테고리 및 날짜별 페이지 모바일/데스크탑 구현

## PR요약

해당 pr은
-   기록 목록을 주제별/날짜별로 나눠 볼 수 있도록 카테고리 및 날짜 페이지를 모바일과 데스크탑 버전으로 각각 구현한 작업입니다.
-   사용자 편의를 고려해 반응형 구조로 설계하였으며, 스타일 파일도 화면 유형에 따라 분리했습니다.

## 관련 이슈

없음

## 작업 내용

-   기록 목록 카테고리 페이지 구현
    -   모바일: `RecordCategory.jsx`, `RecordCategoryStyles.jsx`
    -   데스크탑: `RecordCategoryDesk.jsx`, `RecordCategoryDeskStyles.jsx`
-   기록 목록 날짜별 페이지 구현
    -   모바일: `RecordDate.jsx`, `RecordDateStyles.jsx`
    -   데스크탑: `RecordDateDesk.jsx`, `RecordDateDeskStyles.jsx`
-   홈 및 리포트 헤더, 푸터 등과의 연결 및 화면 구조 통일

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
