### PR TITLE
[feat] 반년/월별 인사이트 페이지 모바일 및 데스크탑 구현

### DIFF
--- a/src/pages/insight/Insight.jsx
+++ b/src/pages/insight/Insight.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as I from './InsightStyles.jsx';
+import Header from '../../components/header/SettingsHeader.jsx';
+import Footer from '../../components/footer/Footer.jsx';
+
+const dummyData = [
+    { month: '2025/01', levels: [50, 80, 60, 40, 30, 20] },
+    { month: '2025/02', levels: [50, 80, 60, 40, 30, 20] },
+    { month: '2025/03', levels: [50, 80, 60, 40, 30, 20] },
+    { month: '2025/04', levels: [50, 80, 60, 40, 30, 20] },
+    { month: '2025/05', levels: [50, 80, 60, 40, 30, 20] },
+    { month: '2025/06', levels: [50, 80, 60, 40, 30, 20] },
+];
+
+const InsightChart = () => {
+    const navigate = useNavigate();
+
+    const goToInsightChart = () => {
+        navigate('/insightchart');
+    };
+
+    const [term, setTerm] = useState('상반기');
+    const [showDropdown, setShowDropdown] = useState(false);
+
+    const toggleDropdown = () => setShowDropdown(!showDropdown);
+    const selectTerm = (t) => {
+        setTerm(t);
+        setShowDropdown(false);
+        // 이후 서버에서 데이터 가져와야 함
+    };
+
+    const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
+
+    return (
+        <I.Container>
+            <Header />
+            <I.Content>
+                {/* <I.Title>2025/상반기 ▼</I.Title> */}
+                <I.TermSelector onClick={toggleDropdown}>
+                    2025/{term} ▼
+                    {showDropdown && (
+                        <I.Dropdown>
+                            <div onClick={() => selectTerm('상반기')}>2025 / 상반기</div>
+                            <div onClick={() => selectTerm('하반기')}>2025 / 하반기</div>
+                        </I.Dropdown>
+                    )}
+                </I.TermSelector>
+                <I.ChartGrid onClick={goToInsightChart}>
+                    {dummyData.map((data, index) => (
+                        <I.ChartBox key={index}>
+                            <I.MonthText>{data.month}</I.MonthText>
+                            <I.ChartBarGroup>
+                                {data.levels.map((value, i) => (
+                                    <I.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
+                                ))}
+                            </I.ChartBarGroup>
+                            <I.ChartLabelGroup>
+                                {['1', '2', '3', '4', '5', '6'].map((level) => (
+                                    <div key={level}>L{level}</div>
+                                ))}
+                            </I.ChartLabelGroup>
+                        </I.ChartBox>
+                    ))}
+                </I.ChartGrid>
+            </I.Content>
+            <Footer />
+        </I.Container>
+    );
+};
+export default InsightChart;

--- a/src/pages/insight/InsightChart.jsx
+++ b/src/pages/insight/InsightChart.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Ic from './InsightChartStyles.jsx';
+import Header from '../../components/header/SettingsHeader.jsx';
+import Footer from '../../components/footer/Footer.jsx';
+
+const InsightChart = () => {
+    const navigate = useNavigate();
+
+    const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
+    const dummyData = {
+        month: '2025/01',
+        levels: [120, 180, 100, 80, 60, 40],
+        comment:
+            'B6님은 1월에 다양한 개념을 잘 이해하고 의미를 정확히 짚어냈어요.\n사고의 깊이가 점점 더해지고 있어요!',
+    };
+
+    const [selectedMonth, setSelectedMonth] = useState('2025/01');
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+    const months = ['2025/01', '2025/02', '2025/03', '2025/04', '2025/05', '2025/06'];
+
+    return (
+        <Ic.Container>
+            <Header />
+            <Ic.Content>
+                <Ic.MonthTitle onClick={() => setIsDropdownOpen(!isDropdownOpen)}>{selectedMonth} ▼</Ic.MonthTitle>
+                {isDropdownOpen && (
+                    <Ic.Dropdown>
+                        {months.map((month) => (
+                            <Ic.DropdownItem
+                                key={month}
+                                onClick={() => {
+                                    setSelectedMonth(month);
+                                    setIsDropdownOpen(false);
+                                }}
+                            >
+                                {month}
+                            </Ic.DropdownItem>
+                        ))}
+                    </Ic.Dropdown>
+                )}
+                <Ic.ChartBox>
+                    <Ic.ChartBarGroup>
+                        {dummyData.levels.map((value, i) => (
+                            <Ic.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
+                        ))}
+                    </Ic.ChartBarGroup>
+                    <Ic.ChartLabelGroup>
+                        {['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5', 'Level 6'].map((label, i) => (
+                            <div key={i}>{label}</div>
+                        ))}
+                    </Ic.ChartLabelGroup>
+                </Ic.ChartBox>
+
+                <Ic.FeedbackBox>
+                    {dummyData.comment.split('\n').map((line, index) => (
+                        <div key={index}>{line}</div>
+                    ))}
+                </Ic.FeedbackBox>
+            </Ic.Content>
+            <Footer />
+        </Ic.Container>
+    );
+};
+export default InsightChart;

--- a/src/pages/insight/InsightChartDesk.jsx
+++ b/src/pages/insight/InsightChartDesk.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as Id from './InsightChartDeskStyles.jsx';
+import HomeDeskHeader from '../../components/header/HomeDeskHeader';
+import Sidebar from '../../components/sidebar/Sidebar';
+
+const InsightChartDesk = () => {
+    const navigate = useNavigate();
+
+    const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
+    const dummyData = {
+        month: '2025/01',
+        levels: [120, 180, 100, 80, 60, 40],
+        comment:
+            'B6님은 1월에 다양한 개념을 잘 이해하고 의미를 정확히 짚어냈어요.\n사고의 깊이가 점점 더해지고 있어요!',
+    };
+
+    const [selectedMonth, setSelectedMonth] = useState('2025/01');
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+    const months = ['2025/01', '2025/02', '2025/03', '2025/04', '2025/05', '2025/06'];
+
+    return (
+        <Id.Container>
+            <HomeDeskHeader />
+            <Id.Content>
+                <Id.MonthTitle onClick={() => setIsDropdownOpen(!isDropdownOpen)}>{selectedMonth} ▼</Id.MonthTitle>
+                {isDropdownOpen && (
+                    <Id.Dropdown>
+                        {months.map((month) => (
+                            <Id.DropdownItem
+                                key={month}
+                                onClick={() => {
+                                    setSelectedMonth(month);
+                                    setIsDropdownOpen(false);
+                                }}
+                            >
+                                {month}
+                            </Id.DropdownItem>
+                        ))}
+                    </Id.Dropdown>
+                )}
+                <Id.ChartBox>
+                    <Id.ChartBarGroup>
+                        {dummyData.levels.map((value, i) => (
+                            <Id.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
+                        ))}
+                    </Id.ChartBarGroup>
+                    <Id.ChartLabelGroup>
+                        {['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5', 'Level 6'].map((label, i) => (
+                            <div key={i}>{label}</div>
+                        ))}
+                    </Id.ChartLabelGroup>
+                </Id.ChartBox>
+
+                <Id.FeedbackBox>
+                    {dummyData.comment.split('\n').map((line, index) => (
+                        <div key={index}>{line}</div>
+                    ))}
+                </Id.FeedbackBox>
+            </Id.Content>
+            <Sidebar />
+        </Id.Container>
+    );
+};
+export default InsightChartDesk;

--- a/src/pages/insight/InsightChartDeskStyles.jsx
+++ b/src/pages/insight/InsightChartDeskStyles.jsx
@@ -1,0 +1,100 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    width: 90%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin-left: 130px;
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    padding: 60px 80px;
+    padding: 40px;
+    margin-top: 10%;
+`;
+
+export const MonthTitle = styled.div`
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 20px;
+    cursor: pointer;
+    position: relative;
+    display: inline-block;
+`;
+
+export const ChartBox = styled.div`
+    background-color: #f6f6f6;
+    border-radius: 20px;
+    padding: 20px;
+    margin-bottom: 30px;
+    min-height: 240px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+`;
+
+export const ChartBarGroup = styled.div`
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    height: 280px;
+    width: 100%;
+`;
+
+export const ChartBar = styled.div`
+    width: 13%;
+    height: ${({ height }) => height};
+    max-height: 280px;
+    background-color: ${({ color }) => color};
+    border-radius: 6px;
+    transition: height 0.3s;
+`;
+
+export const ChartLabelGroup = styled.div`
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: #444;
+`;
+
+export const FeedbackBox = styled.div`
+    background-color: #f6f6f6;
+    border-radius: 20px;
+    padding: 30px;
+    font-weight: bold;
+    font-size: 15px;
+    color: #383636;
+    line-height: 1.5;
+`;
+
+export const Dropdown = styled.div`
+    position: absolute;
+    top: 180px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+    width: 120px;
+`;
+
+export const DropdownItem = styled.div`
+    padding: 10px;
+    cursor: pointer;
+    font-size: 14px;
+    &:hover {
+        background-color: #f0f0f0;
+    }
+`;

--- a/src/pages/insight/InsightChartStyles.jsx
+++ b/src/pages/insight/InsightChartStyles.jsx
@@ -1,0 +1,92 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    padding: 40px;
+    margin-top: 18%;
+`;
+
+export const MonthTitle = styled.div`
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 20px;
+    cursor: pointer;
+`;
+
+export const ChartBox = styled.div`
+    background-color: #f6f6f6;
+    border-radius: 20px;
+    padding: 20px;
+    margin-bottom: 30px;
+    min-height: 240px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+`;
+
+export const ChartBarGroup = styled.div`
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    margin-bottom: 8px;
+    height: 200px;
+`;
+
+export const ChartBar = styled.div`
+    width: 14%;
+    height: ${({ height }) => height};
+    background-color: ${({ color }) => color};
+    border-radius: 6px;
+    transition: height 0.3s;
+`;
+
+export const ChartLabelGroup = styled.div`
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: #444;
+`;
+
+export const FeedbackBox = styled.div`
+    background-color: #f6f6f6;
+    border-radius: 20px;
+    padding: 30px;
+    font-weight: bold;
+    font-size: 15px;
+    color: #383636;
+    line-height: 1.5;
+`;
+
+export const Dropdown = styled.div`
+    position: absolute;
+    top: 130px;
+    left: 40px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+    width: 120px;
+`;
+
+export const DropdownItem = styled.div`
+    padding: 10px;
+    cursor: pointer;
+    font-size: 14px;
+    &:hover {
+        background-color: #f0f0f0;
+    }
+`;

--- a/src/pages/insight/InsightDesk.jsx
+++ b/src/pages/insight/InsightDesk.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as I from './InsightDeskStyles.jsx';
+import HomeDeskHeader from '../../components/header/HomeDeskHeader';
+import Sidebar from '../../components/sidebar/Sidebar';
+
+const dummyData = [
+    { month: '2025/01', levels: [120, 200, 90, 70, 50, 30] },
+    { month: '2025/02', levels: [120, 200, 90, 70, 50, 30] },
+    { month: '2025/03', levels: [120, 200, 90, 70, 50, 30] },
+    { month: '2025/04', levels: [120, 200, 90, 70, 50, 30] },
+    { month: '2025/05', levels: [120, 200, 90, 70, 50, 30] },
+    { month: '2025/06', levels: [120, 200, 90, 70, 50, 30] },
+];
+
+const InsightDesk = () => {
+    const navigate = useNavigate();
+
+    const goToInsightChart = () => {
+        navigate('/insightchart');
+    };
+
+    const [term, setTerm] = useState('상반기');
+    const [showDropdown, setShowDropdown] = useState(false);
+
+    const toggleDropdown = () => setShowDropdown(!showDropdown);
+    const selectTerm = (t) => {
+        setTerm(t);
+        setShowDropdown(false);
+        // 이후 서버에서 데이터 가져와야 함
+    };
+
+    const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
+
+    return (
+        <I.Container>
+            <HomeDeskHeader />
+            <I.Content>
+                {/* <I.Title>2025/상반기 ▼</I.Title> */}
+                <I.TermSelector onClick={toggleDropdown}>
+                    2025 / {term} ▼
+                    {showDropdown && (
+                        <I.Dropdown>
+                            <div onClick={() => selectTerm('상반기')}>2025 / 상반기</div>
+                            <div onClick={() => selectTerm('하반기')}>2025 / 하반기</div>
+                        </I.Dropdown>
+                    )}
+                </I.TermSelector>
+                <I.ChartGrid onClick={goToInsightChart}>
+                    {dummyData.map((data, index) => (
+                        <I.ChartBox key={index}>
+                            <I.MonthText>{data.month}</I.MonthText>
+                            <I.ChartBarGroup>
+                                {data.levels.map((value, i) => (
+                                    <I.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
+                                ))}
+                            </I.ChartBarGroup>
+                            <I.ChartLabelGroup>
+                                {['1', '2', '3', '4', '5', '6'].map((level) => (
+                                    <div key={level}>L{level}</div>
+                                ))}
+                            </I.ChartLabelGroup>
+                        </I.ChartBox>
+                    ))}
+                </I.ChartGrid>
+            </I.Content>
+            <Sidebar />
+        </I.Container>
+    );
+};
+export default InsightDesk;

--- a/src/pages/insight/InsightDeskStyles.jsx
+++ b/src/pages/insight/InsightDeskStyles.jsx
@@ -1,0 +1,98 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    width: 90%;
+    margin: 0 auto;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin-left: 130px;
+`;
+
+export const TermSelector = styled.div`
+    font-weight: bold;
+    margin-top: 9%;
+    margin-bottom: 3%;
+    position: relative;
+    font-size: 20px;
+    cursor: pointer;
+`;
+
+export const Dropdown = styled.div`
+    position: absolute;
+    /* top: 30px;
+    left: 0; */
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 5px 0;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    div {
+        padding: 6px 14px;
+        cursor: pointer;
+        &:hover {
+            background-color: #f0f0f0;
+        }
+    }
+`;
+
+export const Content = styled.div`
+    padding: 40px;
+    width: 100%;
+`;
+
+export const ChartGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 40px 60px;
+    justify-content: center;
+    margin-top: 20px;
+    cursor: pointer;
+    width: 100%;
+`;
+
+export const ChartBox = styled.div`
+    background-color: #f6f6f6;
+    border-radius: 20px;
+    padding: 20px;
+    width: 100%;
+    box-sizing: border-box;
+`;
+
+export const MonthText = styled.div`
+    font-size: 14px;
+    text-align: right;
+    margin-bottom: 8px;
+`;
+
+export const ChartBarGroup = styled.div`
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+    height: 160px;
+`;
+
+export const ChartBar = styled.div`
+    width: 16%;
+    height: ${({ height }) => height || '40px'};
+    max-height: 160px;
+    background-color: ${({ color }) => color || '#8ec9ff'};
+    border-radius: 4px;
+    transition: height 0.3s;
+`;
+
+export const ChartLabelGroup = styled.div`
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    color: #555;
+    margin-top: 5px;
+`;

--- a/src/pages/insight/InsightStyles.jsx
+++ b/src/pages/insight/InsightStyles.jsx
@@ -1,0 +1,86 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+`;
+
+export const TermSelector = styled.div`
+    font-weight: bold;
+    margin-top: 19%;
+    margin-bottom: -2%;
+    position: relative;
+    cursor: pointer;
+`;
+
+export const Dropdown = styled.div`
+    position: absolute;
+    top: 30px;
+    left: 0;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 5px 0;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    div {
+        padding: 6px 14px;
+        cursor: pointer;
+        &:hover {
+            background-color: #f0f0f0;
+        }
+    }
+`;
+
+export const Content = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    padding: 40px;
+`;
+
+export const ChartGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+    margin-top: 20px;
+    cursor: pointer;
+`;
+
+export const ChartBox = styled.div`
+    background-color: #f6f6f6;
+    border-radius: 20px;
+    padding: 10px;
+`;
+
+export const MonthText = styled.div`
+    font-size: 14px;
+    text-align: right;
+    margin-bottom: 8px;
+`;
+
+export const ChartBarGroup = styled.div`
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+`;
+
+export const ChartBar = styled.div`
+    width: 16%;
+    height: ${({ height }) => height || '40px'};
+    background-color: ${({ color }) => color || '#8ec9ff'};
+    border-radius: 4px;
+`;
+
+export const ChartLabelGroup = styled.div`
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    color: #555;
+    margin-top: 5px;
+`;


### PR DESCRIPTION
# [feature/insight] 반년/월별 인사이트 페이지 모바일 및 데스크탑 구현

## PR요약

해당 pr은
-   인사이트 기능을 모바일과 데스크탑 환경에 맞게 반응형으로 구현했습니다.
-   반년 단위 인사이트(Insight.jsx / InsightDesk.jsx)와 월별 인사이트(InsightChart.jsx / InsightChartDesk.jsx)를 각각 구성했습니다.

## 관련 이슈

없음

## 작업 내용

-   모바일/데스크탑 반응형 인사이트 화면 분리 및 개발
    -   Insight.jsx, InsightDesk.jsx: 반년 인사이트 차트 및 기간 선택 드롭다운 구성
    -   InsightChart.jsx, InsightChartDesk.jsx: 월별 인사이트 상세 차트 및 피드백 UI 구현
-   스타일 분리
    -   각 페이지별로 스타일 파일을 분리하여 유지보수성 향상 (예: InsightChartStyles.jsx 등)
-   모바일과 데스크탑에서 동일한 기능이지만 서로 다른 레이아웃 요구로 인해 컴포넌트를 분리 개발함

## 공유사항

-   추후 실제 데이터 연동이 필요함 (현재는 dummyData 사용 중)
-   `Sidebar`, `HomeDeskHeader`, `Footer` 등 레이아웃 관련 컴포넌트와의 조화도 함께 확인 필요

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
