### PR TITLE
[feat] 라우터 경로 설정 및 페이지 연결 (Notification, TermsPage, Setting)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,9 @@ import RecordCategory from './pages/chatRecord/RecordCategoryPage';
 import RecordDate from './pages/chatRecord/RecordDatePage';
 import Insight from './pages/insight/InsightPage';
 import InsightChart from './pages/insight/InsightChartPage';
+import Notification from './pages/notification/Notification';
+import TermsPage from './components/setting/TermsPage';
+import Setting from './pages/setting/SettingPage';
 
 function App() {
     return (
@@ -35,6 +38,10 @@ function App() {
                 <Route path="/recorddate" element={<RecordDate />} />
                 <Route path="/insight" element={<Insight />} />
                 <Route path="/insightchart" element={<InsightChart />} />
+                <Route path="/notification" element={<Notification />} />
+                <Route path="/termspage" element={<TermsPage />} />
+                <Route path="/setting" element={<Setting />} />
+                <Route path="/settingpage" element={<Setting />} />
             </Routes>
         </BrowserRouter>
     );


### PR DESCRIPTION
# [feature/setup-router] 라우터 경로 설정 및 페이지 연결 (Notification, TermsPage, Setting)

## PR요약

해당 pr은 다음 페이지들의 라우터 경로 설정과 페이지 연결 작업을 포함합니다.
-   Notification 페이지
-   TermsPage (서비스 약관 통합 페이지)
-   Setting 페이지 (계정/서비스 설정)
라우터가 정상적으로 연결되어 각 경로(`/notification`, `/termspage`, `/setting`)로 이동 시 해당 컴포넌트가 출력됩니다.

## 관련 이슈

없음

## 작업 내용

-   `App.js`에 다음 라우터 경로 추가
    -   `/notification` → `Notification` 컴포넌트 연결
    -   `/termspage` → `TermsPage` 컴포넌트 연결
    -   `/setting` → `SettingPage` 컴포넌트 연결

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
