### PR TITLE
[feat] 설정 페이지 기능 및 헤더 개선 (Setting 페이지, 드롭다운, 문구 출력 등)

### DIFF
--- a/src/components/header/HomeDeskHeader.jsx
+++ b/src/components/header/HomeDeskHeader.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import * as Dh from './HomeDeskHeaderStyles.jsx';
+import Logo from '../../assets/LogoIcon.png';
+import Report from '../../assets/Report.png';
+import RectangleHeader from '../../assets/RectangleHeader.svg';
+
+const HomeDeskHeader = () => {
+    const location = useLocation();
+
+    const navigate = useNavigate();
+
+    const goToReport = () => {
+        navigate('/report');
+    };
+
+    return (
+        <Dh.Container>
+            <Dh.Logo>
+                <img src={Logo} />
+            </Dh.Logo>
+            <Dh.Body>
+                <Dh.BackgroundImg src={RectangleHeader} />
+                {location.pathname.startsWith('/record') ? (
+                    <Dh.TextRecord>리포트 기록을 확인해 보세요!</Dh.TextRecord>
+                ) : location.pathname === '/insight' ? (
+                    <Dh.TextRecord>상반기 히스토그램을 확인해 보세요!</Dh.TextRecord>
+                ) : location.pathname === '/insightchart' ? (
+                    <Dh.TextRecord>월별 히스토그램을 확인해 보세요!</Dh.TextRecord>
+                ) : location.pathname === '/setting' ? (
+                    <Dh.TextRecord>나의 계정 정보를 확인해 보세요!</Dh.TextRecord>
+                ) : (
+                    <>
+                        <Dh.Title>나의 AI 파트너, WIDER와</Dh.Title>
+                        <Dh.Text>오늘의 대화를 시작해 보세요!</Dh.Text>
+                    </>
+                )}
+            </Dh.Body>
+            {location.pathname === '/chat' && (
+                <Dh.Report onClick={goToReport}>
+                    <img src={Report} />
+                </Dh.Report>
+            )}
+        </Dh.Container>
+    );
+};
+export default HomeDeskHeader;

--- a/src/components/header/SettingsHeader.jsx
+++ b/src/components/header/SettingsHeader.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import * as Sh from './SettingsHeaderStyles.jsx';
+import Logo from '../../assets/LogoIcon.png';
+import Rectangle from '../../assets/Rectangle.svg';
+import Setting from '../../assets/Setting.png';
+
+const SettingsHeader = () => {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const [showDropdown, setShowDropdown] = useState(false);
+
+    const titleText =
+        location.pathname === '/insight'
+            ? '상반기 히스토그램을 확인 해 보세요!'
+            : location.pathname === '/insightchart'
+            ? '월별 히스토그램을 확인해 보세요!'
+            : '리포트 기록을 확인해 보세요!';
+
+    const toggleDropdown = () => {
+        setShowDropdown((prev) => !prev);
+    };
+
+    const goToTermsPage = () => {
+        navigate('/termspage');
+    };
+
+    return (
+        <>
+            <Sh.Container>
+                <Sh.Left>
+                    <Sh.Logo>
+                        <img src={Logo} />
+                    </Sh.Logo>
+                    <Sh.Title>
+                        <Sh.Rectangle>
+                            <img src={Rectangle} />
+                        </Sh.Rectangle>
+                        <Sh.TitleText>{titleText}</Sh.TitleText>
+                    </Sh.Title>
+                </Sh.Left>
+                <Sh.Right>
+                    <Sh.Setting onClick={toggleDropdown}>
+                        <img src={Setting} />
+                    </Sh.Setting>
+                </Sh.Right>
+            </Sh.Container>
+            {showDropdown && (
+                <Sh.DropdownBox>
+                    <Sh.SectionTitle>계정</Sh.SectionTitle>
+                    <Sh.ItemRow nonHover>
+                        <span>아이디</span> <span style={{ color: '#aaa' }}>b6shift5</span>
+                    </Sh.ItemRow>
+                    <Sh.ItemRow>비밀번호 변경</Sh.ItemRow>
+                    <Sh.ItemRow>채팅 알림 기능</Sh.ItemRow>
+                    <Sh.SectionTitle>서비스</Sh.SectionTitle>
+                    <Sh.ItemRow onClick={goToTermsPage}>서비스 이용 약관</Sh.ItemRow>
+                    <Sh.ItemRow>로그아웃</Sh.ItemRow>
+                </Sh.DropdownBox>
+            )}
+        </>
+    );
+};
+export default SettingsHeader;

--- a/src/components/header/SettingsHeaderStyles.jsx
+++ b/src/components/header/SettingsHeaderStyles.jsx
@@ -1,0 +1,114 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: fixed;
+    top: 0;
+    margin: 0 auto;
+    width: 393px;
+    height: 80px;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    text-align: center;
+    background-color: #91c0f2;
+    z-index: 10;
+`;
+
+export const Left = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+`;
+
+export const Logo = styled.div`
+    img {
+        width: 65px;
+        height: 65px;
+    }
+    margin-left: 10%;
+`;
+
+export const Title = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 300px;
+    height: 40px;
+    flex-shrink: 0;
+`;
+
+export const Rectangle = styled.div`
+    position: absolute;
+    left: 0;
+    top: 5;
+    img {
+        width: 210px;
+        height: 90px;
+    }
+`;
+
+export const TitleText = styled.div`
+    font-size: 13px;
+    font-weight: bold;
+    color: #4e4e4e;
+    font-weight: bold;
+    white-space: nowrap;
+    margin-left: -90px;
+    z-index: 1;
+`;
+
+export const Right = styled.div`
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+    margin-right: 20px;
+`;
+
+export const Setting = styled.div`
+    img {
+        width: 45px;
+        height: 45px;
+    }
+    cursor: pointer;
+    position: relative;
+`;
+
+export const DropdownBox = styled.div`
+    position: absolute;
+    top: 80px;
+    right: 20px;
+    width: 260px;
+    background: #fff;
+    border-radius: 20px;
+    padding: 20px;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.15);
+    z-index: 10;
+`;
+
+export const SectionTitle = styled.div`
+    font-weight: bold;
+    margin-bottom: 10px;
+    margin-top: 10px;
+`;
+
+export const ItemRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    padding: 12px 16px;
+    font-size: 14px;
+    cursor: pointer;
+
+    ${({ nonHover }) =>
+        !nonHover &&
+        `
+        &:hover {
+            background-color: #f2f2f2;
+            border-radius: 10px;
+        }
+    `}
+`;

--- a/src/pages/setting/Setting.jsx
+++ b/src/pages/setting/Setting.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as S from './SettingStyles.jsx';
+import HomeDeskHeader from '../../components/header/HomeDeskHeader.jsx';
+import Sidebar from '../../components/sidebar/Sidebar.jsx';
+import TermsPage from '../../components/setting/TermsPage.jsx';
+
+const Setting = () => {
+    const navigate = useNavigate();
+
+    const goToTermsPage = () => {
+        navigate('/termspage');
+    };
+
+    return (
+        <S.Container>
+            <HomeDeskHeader />
+            <S.Content>
+                <S.Section>
+                    <S.SectionTitle>계정</S.SectionTitle>
+                    <S.Box>
+                        <S.ItemRow $nonHover>
+                            <span>아이디</span>
+                            <span style={{ color: '#aaa' }}>b6shift5</span>
+                        </S.ItemRow>
+                        <S.ItemRow>비밀번호 변경</S.ItemRow>
+                    </S.Box>
+                </S.Section>
+                <S.Section>
+                    <S.SectionTitle>서비스</S.SectionTitle>
+                    <S.Box>
+                        <S.ItemRow onClick={goToTermsPage}>서비스 이용 약관</S.ItemRow>
+                        <S.ItemRow>로그아웃</S.ItemRow>
+                        <S.ItemRow>회원 탈퇴</S.ItemRow>
+                    </S.Box>
+                </S.Section>
+            </S.Content>
+            <Sidebar />
+        </S.Container>
+    );
+};
+export default Setting;

--- a/src/pages/setting/SettingStyles.jsx
+++ b/src/pages/setting/SettingStyles.jsx
@@ -1,0 +1,58 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    width: 90%;
+    margin: 0 auto;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin-left: 130px;
+`;
+
+export const Content = styled.div`
+    padding: 80px;
+    width: 100%;
+    margin-top: 10%;
+`;
+
+export const Section = styled.div`
+    margin-bottom: 32px;
+    width: 100%;
+`;
+
+export const SectionTitle = styled.h2`
+    font-size: 25px;
+    font-weight: bold;
+    margin-bottom: 15px;
+    text-align: left;
+`;
+
+export const Box = styled.div`
+    background-color: #dff1ff;
+    border-radius: 16px;
+    padding: 20px;
+`;
+
+export const ItemRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    padding: 15px 10px;
+    font-size: 16px;
+    margin-left: 15px;
+
+    cursor: ${({ $nonHover }) => ($nonHover ? 'default' : 'pointer')};
+
+    ${({ $nonHover }) =>
+        !$nonHover &&
+        `
+        &:hover {
+            background-color: #bee2fd;
+            border-radius: 10px;
+        }
+    `}
+`;


### PR DESCRIPTION
# [feature/setting] 설정 페이지 기능 및 헤더 개선 (Setting 페이지, 드롭다운, 문구 출력 등)

## PR요약

해당 pr은
-   데스크탑 설정 페이지 구현 및 상단 헤더 기능 개선을 위한 작업입니다.
-   `/setting` 경로 접근 시 계정 및 서비스 관련 항목이 표시되며, 상단 헤더에서는 해당 경로에 맞는 안내 문구가 출력됩니다. 또한 설정 아이콘 클릭 시 드롭다운 메뉴가 노출됩니다.

## 관련 이슈

없음

## 작업 내용

-   `/setting` 경로 접근 시 설정 페이지 렌더링
    -   계정: 아이디 표시, 비밀번호 변경
    -   서비스: 이용 약관 이동, 로그아웃, 회원 탈퇴
-   `HomeDeskHeader.jsx`
    -   `/setting`일 때 `"나의 계정 정보를 확인해 보세요!"` 문구 출력 기능 추가
-   `SettingsHeader.jsx`
    -   설정 아이콘 클릭 시 드롭다운 메뉴 표시
    -   서비스 약관 이동 (`/termspage`) 기능 연결

## 공유사항

-   추후 로그인 상태 확인 및 로그아웃/탈퇴 동작 연동 필요

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
