### PR TITLE
[fix] 사이드바에서 Setting 경로 이동 로직 수정

### DIFF
--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -35,7 +35,7 @@ const Sidebar = () => {
     };
 
     const goToSetting = () => {
-        navigate('/settingdesk');
+        navigate('/setting');
     };
 
     return (

--- a/src/components/sidebar/SidebarStyles.jsx
+++ b/src/components/sidebar/SidebarStyles.jsx
@@ -19,11 +19,11 @@ export const TopNav = styled.div`
     display: flex;
     flex-direction: column;
     gap: 15px;
-    margin-top: 0px;
+    margin-top: -10px;
 `;
 
 export const BottomNav = styled.div`
-    margin-top: 180px;
+    margin-top: 250px;
 `;
 
 export const Chat = styled.div`


### PR DESCRIPTION
# [fix/sidebar] 사이드바에서 Setting 경로 이동 로직 수정

## PR요약

해당 pr은
-   사이드바에서 `/setting` 경로로 정상 이동되지 않던 문제를 해결한 작업입니다.
-   사용자가 사이드바 하단의 설정 아이콘 클릭 시, 설정 페이지로 올바르게 이동하도록 수정했습니다.

## 관련 이슈

없음

## 작업 내용

-   사이드바 내 `/setting` 경로 연결

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
