### PR TITLE
[feat] 홈 화면에서 알림 페이지로 이동 기능 추가

### DIFF
--- a/src/pages/home/HomeScreen.jsx
+++ b/src/pages/home/HomeScreen.jsx
@@ -4,7 +4,7 @@ import * as H from './HomeScreenStyles.jsx';
 import LogoIcon from '../../assets/LogoIcon.png';
 import BellOff from '../../assets/BellOff.png';
 // import BellOn from '../../assets/BellOn.png';
-import Footer from '../../components/footer/Footer';
+import Footer from '../../components/footer/Footer.jsx';
 import RectangleHeader from '../../assets/RectangleHeader.svg';
 
 const Home = () => {
@@ -18,6 +18,10 @@ const Home = () => {
         navigate('/report');
     };
 
+    const goToNotification = () => {
+        navigate('/notification');
+    };
+
     return (
         <H.Container>
             <H.Header>
@@ -29,7 +33,7 @@ const Home = () => {
                     <H.ServiceName>나의 AI 파트너, WIDER와</H.ServiceName>
                     <H.ServiceTagline>오늘의 대화를 시작해 보세요!</H.ServiceTagline>
                 </H.HeaderText>
-                <H.BellOff>
+                <H.BellOff onClick={goToNotification}>
                     <img src={BellOff} />
                 </H.BellOff>
             </H.Header>


### PR DESCRIPTION
# [feature/home] 홈 화면에서 알림 페이지로 이동 기능 추가

## PR요약

해당 pr은
-   홈 화면에서 우측 상단 알림 아이콘 클릭 시 알림 페이지(`/notification`)로 이동할 수 있는 기능을 추가한 작업입니다.
-   사용자 접근성을 고려해 홈에서 알림 확인 흐름을 자연스럽게 연결했습니다.

## 관련 이슈

없음

## 작업 내용

-   홈 화면(`HomeScreen.jsx`)에 `goToNotification` 함수 추가
-   알림 버튼 영역(`H.BellOff`)에 클릭 이벤트 핸들러 적용

## 공유사항

-   추후 알림 상태에 따라 BellOn/BellOff 이미지 전환 기능을 추가할 계획입니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
