### PR TITLE
[refactor] SettingPage 컴포넌트로 컴포넌트명 변경

### DIFF
--- a/src/pages/setting/SettingPage.jsx
+++ b/src/pages/setting/SettingPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import SettingMobile from '../insight/Insight';
 import SettingDesktop from './Setting';
 
-const ReportPage = () => {
+const SettingPage = () => {
     const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
 
     useEffect(() => {
@@ -16,4 +16,4 @@ const ReportPage = () => {
     return isMobile ? <SettingMobile /> : <SettingDesktop />;
 };
 
-export default ReportPage;
+export default SettingPage;


### PR DESCRIPTION
# [feature/responsive] SettingPage 컴포넌트로 컴포넌트명 변경

## PR요약

해당 pr은
-   기존에 잘못 지정되어 있던 컴포넌트명을 `ReportPage`에서 `SettingPage`로 정정하여 파일명과 컴포넌트명이 일치하도록 리팩토링한 작업입니다.
-   명확한 네이밍을 통해 유지보수성을 높이고자 했습니다.

## 관련 이슈

없음

## 작업 내용

-   `SettingPage.jsx` 파일 내 기존 컴포넌트명 `ReportPage` → `SettingPage`로 변경
-   파일명과 컴포넌트명을 일치시켜 코드의 직관성과 관리 효율 향상

## 공유사항

-   해당 컴포넌트는 반응형 설정 페이지로 모바일/데스크탑 구분 렌더링을 수행합니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
