### PR TITLE
[feat] 약관 동의 페이지(TermsPage) 구현 및 약관 상세 페이지 이동 기능 추가

### DIFF
--- a/src/components/setting/TermsPage.jsx
+++ b/src/components/setting/TermsPage.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as T from './TermsPageStyles.jsx';
+import ArrowRight from '../../assets/ArrowRight.png';
+import ArrowLeft from '../../assets/ArrowLeft.png';
+
+const TermsPage = () => {
+    const navigate = useNavigate();
+
+    const goToServiceTerms = () => {
+        navigate('/serviceterms');
+    };
+
+    const goToPrivacyTerms = () => {
+        navigate('/privacyterms');
+    };
+
+    const goToBack = () => {
+        navigate(-1);
+    };
+
+    return (
+        <T.Container>
+            <T.ArrowLeft onClick={goToBack}>
+                <img src={ArrowLeft} />
+            </T.ArrowLeft>
+            <T.TitleWider>WIDER</T.TitleWider>
+            <T.TitleText>약관 동의</T.TitleText>
+            <T.TermsRequired>
+                <T.TermsRequiredText>WIDER 서비스 이용 약관</T.TermsRequiredText>
+                <T.TermsRequiredImgArrow onClick={goToServiceTerms}>
+                    <img src={ArrowRight} />
+                </T.TermsRequiredImgArrow>
+            </T.TermsRequired>
+            <T.PrivacyRequired>
+                <T.PrivacyRequiredText>개인정보 수집 이용 동의</T.PrivacyRequiredText>
+                <T.PrivacyRequiredImgArrow onClick={goToPrivacyTerms}>
+                    <img src={ArrowRight} />
+                </T.PrivacyRequiredImgArrow>
+            </T.PrivacyRequired>
+        </T.Container>
+    );
+};
+export default TermsPage;

--- a/src/components/setting/TermsPageStyles.jsx
+++ b/src/components/setting/TermsPageStyles.jsx
@@ -1,0 +1,82 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 393px;
+    height: 100vh;
+    min-height: 100vh;
+    padding: 30px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+`;
+
+export const ArrowLeft = styled.div`
+    cursor: pointer;
+`;
+
+export const TitleWider = styled.div`
+    font-size: 24px;
+    color: #6ba9ec;
+    font-weight: bold;
+    margin-top: 30px;
+`;
+
+export const TitleText = styled.div`
+    font-size: 24px;
+    font-weight: bold;
+    margin-top: 5px;
+`;
+
+export const TermsRequired = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 50px;
+    margin-top: 50px;
+`;
+
+export const TermsRequiredImgCheck = styled.div`
+    cursor: pointer;
+    img {
+        width: 30px;
+        height: 30px;
+        object-fit: contain;
+    }
+`;
+
+export const TermsRequiredText = styled.div`
+    font-size: 18px;
+    font-weight: bold;
+`;
+
+export const TermsRequiredImgArrow = styled.div`
+    cursor: pointer;
+`;
+
+export const PrivacyRequired = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 15px;
+`;
+
+export const PrivacyRequiredImgCheck = styled.div`
+    cursor: pointer;
+    img {
+        width: 30px;
+        height: 30px;
+        object-fit: contain;
+    }
+`;
+
+export const PrivacyRequiredText = styled.div`
+    font-size: 18px;
+    font-weight: bold;
+`;
+
+export const PrivacyRequiredImgArrow = styled.div`
+    cursor: pointer;
+`;


### PR DESCRIPTION
# [feature/setting] 약관 동의 페이지(TermsPage) 구현 및 약관 상세 페이지 이동 기능 추가

## PR요약

해당 pr은
-   사용자에게 서비스 이용 약관과 개인정보 수집·이용 동의를 안내하는 약관 동의 페이지(TermsPage)를 구현하고, 각 항목 클릭 시 상세 페이지로 이동할 수 있도록 기능을 추가한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `TermsPage.jsx` 컴포넌트 구현
    -   서비스 이용 약관, 개인정보 수집 이용 항목 UI 추가
    -   항목 클릭 시 각각 `/serviceterms`, `/privacyterms` 경로로 이동되도록 구현
-  뒤로가기 버튼 클릭 시 이전 페이지로 돌아가는 로직(`navigate(-1)`) 추가
-   관련 스타일 정의(`TermsPageStyles.jsx`) 및 전체 디자인 반영

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
