### PR TITLE
[build] Vercel 배포용 GitHub Actions 워크플로 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: git push into another repo to deploy to vercel
+
+on:
+    push:
+        branches: [main]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        container: pandoc/latex
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install mustache (to update the date)
+              run: apk add ruby && gem install mustache
+            - name: creates output
+              run: sh ./build.sh
+            - name: Pushes to another repository
+              id: push_directory
+              uses: cpina/github-action-push-to-another-repository@main
+              env:
+                  API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+              with:
+                  source-directory: 'output'
+                  destination-github-username: JInsunnya
+                  destination-repository-name: WIDER-Client
+                  user-email: ${{ secrets.EMAIL }}
+                  commit-message: ${{ github.event.commits[0].message }}
+                  target-branch: main
+            - name: Test get variable exported by push-to-another-repository
+              run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./WIDER-Client/* ./output
+cp -R ./output ./WIDER-Client/


### PR DESCRIPTION
# [build/vercel-deploy] Vercel 배포용 GitHub Actions 워크플로 추가

## PR요약

해당 pr은
-   GitHub Actions를 이용하여 `main` 브랜치에 push 될 떄 자동으로 `output` 디렉토리를 다른 저장소로 push 하는 워크플로를 설정한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `build.sh` 스크립트 추가
    -   프로젝트 루트에서 `output` 디렉토리를 생성하고 빌드 결과물 복사
-   `.github/workflows/main.yml` 워크플로 추가
    -   GitHub Actions를 통해 빌드 및 배포 자동화
    -   `cpina/github-action-push-to-another-repository` 액션 사용
    -   `secrets`에 저장된 토큰과 이메일 사용

## 공유사항

-   `AUTO_ACTIONS`와` EMAIL`은 GitHub Repository Secrets에 미리 등록되어 있습니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
