### PR TITLE
feat: 비밀번호 변경 UI 추가

### DIFF
--- a/src/components/header/SettingsHeader.jsx
+++ b/src/components/header/SettingsHeader.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { changePassword } from '../../store/userSlice';
 import * as Sh from './SettingsHeaderStyles.jsx';
 import Logo from '../../assets/LogoIcon.png';
 import Rectangle from '../../assets/Rectangle.svg';
@@ -9,7 +10,17 @@ import Setting from '../../assets/Setting.png';
 const SettingsHeader = () => {
     const navigate = useNavigate();
     const location = useLocation();
+    const user = useSelector((state) => state.user);
     const [showDropdown, setShowDropdown] = useState(false);
+    const [showPasswordBox, setShowPasswordBox] = useState(false);
+    const [passwords, setPasswords] = useState({
+        currentPassword: '',
+        newPassword1: '',
+        newPassword2: '',
+    });
+
+    const dispatch = useDispatch();
+    const token = useSelector((state) => state.user.token);
 
     const titleText =
         location.pathname === '/insight'
@@ -24,6 +35,52 @@ const SettingsHeader = () => {
 
     const goToTermsPage = () => {
         navigate('/termspage');
+    };
+
+    const handlePasswordChangeClick = () => {
+        setShowDropdown(false);
+        setShowPasswordBox(true);
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setPasswords((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    };
+
+    const handleSubmitPasswordChange = async () => {
+        console.log('현재 전달되는 토큰:', token);
+        console.log('current:', passwords.currentPassword);
+        console.log('new1:', passwords.newPassword1);
+        console.log('new2:', passwords.newPassword2);
+
+        try {
+            const passwordData = {
+                currentPassword: passwords.currentPassword,
+                newPassword1: passwords.newPassword1,
+                newPassword2: passwords.newPassword2,
+            };
+
+            console.log('비번 변경 요청에 사용할 토큰:', token);
+
+            const resultAction = await dispatch(changePassword({ passwordData, token }));
+
+            if (changePassword.fulfilled.match(resultAction)) {
+                alert('비밀번호가 성공적으로 변경되었습니다.');
+                setShowPasswordBox(false);
+                setPasswords({
+                    currentPassword: '',
+                    newPassword1: '',
+                    newPassword2: '',
+                });
+            } else {
+                alert(resultAction.payload?.message || '비밀번호 변경 실패');
+            }
+        } catch (e) {
+            alert('알 수 없는 에러가 발생했습니다.');
+        }
     };
 
     return (
@@ -50,14 +107,42 @@ const SettingsHeader = () => {
                 <Sh.DropdownBox>
                     <Sh.SectionTitle>계정</Sh.SectionTitle>
                     <Sh.ItemRow nonHover>
-                        <span>아이디</span> <span style={{ color: '#aaa' }}>b6shift5</span>
+                        <span>아이디</span> <span style={{ color: '#aaa' }}>{user.id}</span>
                     </Sh.ItemRow>
-                    <Sh.ItemRow>비밀번호 변경</Sh.ItemRow>
+                    <Sh.ItemRow onClick={handlePasswordChangeClick}>비밀번호 변경</Sh.ItemRow>
                     <Sh.ItemRow>채팅 알림 기능</Sh.ItemRow>
                     <Sh.SectionTitle>서비스</Sh.SectionTitle>
                     <Sh.ItemRow onClick={goToTermsPage}>서비스 이용 약관</Sh.ItemRow>
                     <Sh.ItemRow>로그아웃</Sh.ItemRow>
                 </Sh.DropdownBox>
+            )}
+            {showPasswordBox && (
+                <Sh.PasswordOverlay>
+                    <Sh.PasswordBox>
+                        <Sh.Input
+                            type="password"
+                            name="currentPassword"
+                            placeholder="현재 비밀번호"
+                            value={passwords.currentPassword}
+                            onChange={handleInputChange}
+                        />
+                        <Sh.Input
+                            type="password"
+                            name="newPassword1"
+                            placeholder="새 비밀번호"
+                            value={passwords.newPassword1}
+                            onChange={handleInputChange}
+                        />
+                        <Sh.Input
+                            type="password"
+                            name="newPassword2"
+                            placeholder="새 비밀번호 확인"
+                            value={passwords.newPassword2}
+                            onChange={handleInputChange}
+                        />
+                        <Sh.SubmitButton onClick={handleSubmitPasswordChange}>변경하기</Sh.SubmitButton>
+                    </Sh.PasswordBox>
+                </Sh.PasswordOverlay>
             )}
         </>
     );

--- a/src/components/header/SettingsHeaderStyles.jsx
+++ b/src/components/header/SettingsHeaderStyles.jsx
@@ -112,3 +112,45 @@ export const ItemRow = styled.div`
         }
     `}
 `;
+
+export const PasswordOverlay = styled.div`
+    position: absolute;
+    top: 80px;
+    right: 20px;
+    width: 280px;
+    background-color: white;
+    border-radius: 16px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    z-index: 999;
+    padding: 20px;
+`;
+
+export const PasswordBox = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+`;
+
+export const Input = styled.input`
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 14px;
+    &:focus {
+        outline: none;
+        border: 2px solid #6ba9ec;
+    }
+`;
+
+export const SubmitButton = styled.button`
+    padding: 10px;
+    background-color: #6ba9ec;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+
+    &:hover {
+        background-color: #4091e8;
+    }
+`;

--- a/src/pages/setting/Setting.jsx
+++ b/src/pages/setting/Setting.jsx
@@ -1,15 +1,34 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import * as S from './SettingStyles.jsx';
 import HomeDeskHeader from '../../components/header/HomeDeskHeader.jsx';
 import Sidebar from '../../components/sidebar/Sidebar.jsx';
-import TermsPage from '../../components/setting/TermsPage.jsx';
 
 const Setting = () => {
     const navigate = useNavigate();
+    const user = useSelector((state) => state.user);
+    const [showPasswordBox, setShowPasswordBox] = useState(false);
+    const [passwords, setPasswords] = useState({
+        currentPassword: '',
+        newPassword1: '',
+        newPassword2: '',
+    });
 
     const goToTermsPage = () => {
         navigate('/termspage');
+    };
+
+    const togglePasswordBox = () => {
+        setShowPasswordBox((prev) => !prev);
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setPasswords((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
     };
 
     return (
@@ -21,9 +40,35 @@ const Setting = () => {
                     <S.Box>
                         <S.ItemRow $nonHover>
                             <span>아이디</span>
-                            <span style={{ color: '#aaa' }}>b6shift5</span>
+                            <span style={{ color: '#aaa' }}>{user.id}</span>
                         </S.ItemRow>
-                        <S.ItemRow>비밀번호 변경</S.ItemRow>
+                        <S.ItemRow onClick={togglePasswordBox}>비밀번호 변경</S.ItemRow>
+                        {showPasswordBox && (
+                            <S.PasswordBox>
+                                <S.PasswordInput
+                                    type="password"
+                                    name="currentPassword"
+                                    placeholder="현재 비밀번호"
+                                    value={passwords.currentPassword}
+                                    onChange={handleInputChange}
+                                />
+                                <S.PasswordInput
+                                    type="password"
+                                    name="newPassword1"
+                                    placeholder="새 비밀번호"
+                                    value={passwords.newPassword1}
+                                    onChange={handleInputChange}
+                                />
+                                <S.PasswordInput
+                                    type="password"
+                                    name="newPassword2"
+                                    placeholder="새 비밀번호 확인"
+                                    value={passwords.newPassword2}
+                                    onChange={handleInputChange}
+                                />
+                                <S.SubmitButton>변경하기</S.SubmitButton>
+                            </S.PasswordBox>
+                        )}
                     </S.Box>
                 </S.Section>
                 <S.Section>

--- a/src/pages/setting/SettingStyles.jsx
+++ b/src/pages/setting/SettingStyles.jsx
@@ -56,3 +56,33 @@ export const ItemRow = styled.div`
         }
     `}
 `;
+
+export const PasswordBox = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 20px 10px 0 10px;
+    margin-top: 10px;
+`;
+
+export const PasswordInput = styled.input`
+    padding: 10px;
+    font-size: 14px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+`;
+
+export const SubmitButton = styled.button`
+    padding: 10px;
+    font-size: 15px;
+    background-color: #6ba9ec;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    margin-top: 10px;
+    cursor: pointer;
+
+    &:hover {
+        background-color: #4894e5;
+    }
+`;


### PR DESCRIPTION
# [feature/setting] 비밀번호 변경 UI 추가

## PR요약

해당 pr은
-   사용자 설정 화면에 비밀번호 변경 UI를 추가한 작업입니다.
-   사용자가 현재 비밀번호와 새 비밀번호를 입력해 비밀번호를 변경할 수 있도로 구성했습니다.

## 관련 이슈

없음

## 작업 내용

-   SettingsHeader.jsx, Setting.jsx
    -   드롭다운/데스크탑 환경 모두에서 비밀번호 변경 UI 구성
    -   기존 비밀번호, 새 비밀번호, 새 비밀번호 확인 입력 필드 추가
    -   제출 버튼 클릭 시 Redux의 `changePassword` 액션 호출
-   SettingsHeaderStyles.jsx, SettingStyles.jsx
    -   비밀번호 입력창 스타일 정의 (오버레이, 인풋, 버튼 등)
-   기능 목적
    -   사용자 편의성과 보안을 높이기 위해 설정 페이지 내에서 직접 비밀번호를 변경할 수 있도록 UI 제공

## 공유사항

-   현재 비밀번호 변경 시 벡엔드 에러로 인해 기능이 정상 작동하지 않습니다.
-   추후 백엔드 수정 또는 API 응답 형식 확인 후 별도 개선 작업이 필요할 수 있습니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
