### PR TITLE
[feat] 오늘의 질문 API 연동 및 홈 화면 표시 로직 구현

### DIFF
--- a/src/api/home/getTopicApi.js
+++ b/src/api/home/getTopicApi.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const API = process.env.REACT_APP_API_URL;
+
+export const getTodayTopicApi = async (token) => {
+    const response = await axios.get(`${API}/api/chat/topic`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return response.data;
+};

--- a/src/pages/home/HomeDeskScreen.jsx
+++ b/src/pages/home/HomeDeskScreen.jsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getTodayTopicApi } from '../../api/home/getTopicApi';
 import * as Hd from './HomeDeskScreenStyles.jsx';
 import HomeDeskHeader from '../../components/header/HomeDeskHeader';
 import Sidebar from '../../components/sidebar/Sidebar';
 
 const HomeDesk = () => {
     const navigate = useNavigate();
+    const token = useSelector((state) => state.user.token);
+    const [todayTopic, setTodayTopic] = useState('');
 
     const goToChat = () => {
         navigate('/chat');
@@ -15,12 +19,26 @@ const HomeDesk = () => {
         navigate('/report');
     };
 
+    useEffect(() => {
+        const fetchTopic = async () => {
+            try {
+                const res = await getTodayTopicApi(token);
+                setTodayTopic(res || '오늘의 질문을 불러오지 못했습니다.');
+            } catch (e) {
+                setTodayTopic('질문을 불러오는 데 실패했습니다.');
+                console.error(e);
+            }
+        };
+
+        fetchTopic();
+    }, [token]);
+
     return (
         <Hd.Container>
             <HomeDeskHeader />
             <Hd.Content>
                 <Hd.Title>오늘의 질문</Hd.Title>
-                <Hd.Question onClick={goToChat}>대선 후보 단일화의 주요 후보는 누구인가요?</Hd.Question>
+                <Hd.Question onClick={goToChat}>{todayTopic}</Hd.Question>
                 <Hd.StartConversation>터치하여 대화를 시작하세요!</Hd.StartConversation>
                 <Hd.ReportCreated>어제의 리포트가 생성되었습니다!</Hd.ReportCreated>
                 <Hd.ButtonReport onClick={goToReport}>리포트 보러 가기</Hd.ButtonReport>

--- a/src/pages/home/HomeDeskScreenStyles.jsx
+++ b/src/pages/home/HomeDeskScreenStyles.jsx
@@ -28,7 +28,7 @@ export const Title = styled.div`
 export const Question = styled.div`
     background-color: #e6f7ff;
     border-radius: 100px;
-    height: 200px;
+    height: 80px;
     width: 650px;
     font-size: 30px;
     font-weight: bold;

--- a/src/pages/home/HomeScreen.jsx
+++ b/src/pages/home/HomeScreen.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getTodayTopicApi } from '../../api/home/getTopicApi';
 import * as H from './HomeScreenStyles.jsx';
 import LogoIcon from '../../assets/LogoIcon.png';
 import BellOff from '../../assets/BellOff.png';
@@ -9,6 +11,8 @@ import RectangleHeader from '../../assets/RectangleHeader.svg';
 
 const Home = () => {
     const navigate = useNavigate();
+    const token = useSelector((state) => state.user.token);
+    const [todayTopic, setTodayTopic] = useState('');
 
     const goToChat = () => {
         navigate('/chat');
@@ -22,6 +26,20 @@ const Home = () => {
         navigate('/notification');
     };
 
+    useEffect(() => {
+        const fetchTopic = async () => {
+            try {
+                const res = await getTodayTopicApi(token);
+                setTodayTopic(res || '오늘의 질문을 불러오지 못했습니다.');
+            } catch (e) {
+                setTodayTopic('질문을 불러오는 데 실패했습니다.');
+                console.error(e);
+            }
+        };
+
+        fetchTopic();
+    }, [token]);
+
     return (
         <H.Container>
             <H.Header>
@@ -30,8 +48,18 @@ const Home = () => {
                 </H.LogoIcon>
                 <H.HeaderText>
                     <H.BackgroundImg src={RectangleHeader} />
-                    <H.ServiceName>나의 AI 파트너, WIDER와</H.ServiceName>
-                    <H.ServiceTagline>오늘의 대화를 시작해 보세요!</H.ServiceTagline>
+                    <div
+                        style={{
+                            position: 'relative',
+                            zIndex: 1,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <H.ServiceName>나의 AI 파트너, WIDER와</H.ServiceName>
+                        <H.ServiceTagline>오늘의 대화를 시작해 보세요!</H.ServiceTagline>
+                    </div>
                 </H.HeaderText>
                 <H.BellOff onClick={goToNotification}>
                     <img src={BellOff} />
@@ -39,7 +67,7 @@ const Home = () => {
             </H.Header>
             <H.Content>
                 <H.Title>오늘의 질문</H.Title>
-                <H.Question onClick={goToChat}>대선 후보 단일화의 주요 후보는 누구인가요?</H.Question>
+                <H.Question onClick={goToChat}>{todayTopic}</H.Question>
                 <H.StartConversation>
                     터치하여 대화를 <br />
                     시작하세요!

--- a/src/pages/home/HomeScreenStyles.jsx
+++ b/src/pages/home/HomeScreenStyles.jsx
@@ -50,18 +50,22 @@ export const HeaderText = styled.div`
     color: #4e4e4e;
     font-weight: bold;
     font-size: 12px;
-    padding: 10px 10px;
     margin-left: -25px;
 `;
 
 export const ServiceName = styled.div`
-    position: relative;
-    z-index: 1;
+    /* position: relative;
+    z-index: 1; */
+    font-weight: bold;
+    font-size: 12px;
+    color: #4e4e4e;
 `;
 
 export const ServiceTagline = styled.div`
-    position: relative;
-    z-index: 1;
+    /* position: relative;
+    z-index: 1; */
+    font-size: 12px;
+    color: #4e4e4e;
 `;
 
 export const BackgroundImg = styled.img`


### PR DESCRIPTION
# [feature/home] 오늘의 질문 API 연동 및 홈 화면 표시 로직 구현

## PR요약

해당 pr은

-   오늘의 질문을 불러오는 API(`getTodayTopicApi`)를 연동하고, 데스크탑(`HomeDeskScreen`) 및 모바일(`HomeScreen`) 홈 화면에 해당 질문을 출력하는 UI를 구현했습니다.
-   사용자는 해당 질문을 클릭하여 바로 채팅을 시작할 수 있습니다.

## 관련 이슈

해당 작업은 새로운 기능 추가로, 별도의 이슈 번호와는 연결되지 않았습니다.

## 작업 내용

-   `getTopicApi.js`: 오늘의 질문을 GET 방식으로 받아오는 API 함수 구현
-   `HomeDeskScreen.jsx`, `HomeScreen.jsx`: API 연동 및 질문 출력 로직 추가
-   질문 클릭 시 `/chat` 경로로 이동하도록 설정
-   질문 로딩 실패 시 예외 처리 및 기본 메시지 출력 추가

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
