### PR TITLE
[feat] 설정 페이지 비밀번호 변경·로그아웃·회원탈퇴 기능 구현 및 채팅에서 리포트로 sessionId 전달

### DIFF
--- a/src/components/header/HomeDeskHeader.jsx
+++ b/src/components/header/HomeDeskHeader.jsx
@@ -1,18 +1,22 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import * as Dh from './HomeDeskHeaderStyles.jsx';
 import Logo from '../../assets/LogoIcon.png';
 import Report from '../../assets/Report.png';
 import RectangleHeader from '../../assets/RectangleHeader.svg';
 
-const HomeDeskHeader = () => {
+const HomeDeskHeader = ({ sessionId }) => {
     const location = useLocation();
-
     const navigate = useNavigate();
 
     const goToReport = () => {
-        navigate('/report');
+        if (sessionId) {
+            navigate('/report', {
+                state: { sessionId },
+            });
+        } else {
+            console.warn('sessionId 없음');
+        }
     };
 
     return (
@@ -22,18 +26,27 @@ const HomeDeskHeader = () => {
             </Dh.Logo>
             <Dh.Body>
                 <Dh.BackgroundImg src={RectangleHeader} />
-                {location.pathname.startsWith('/record') ? (
-                    <Dh.TextRecord>리포트 기록을 확인해 보세요!</Dh.TextRecord>
-                ) : location.pathname === '/insight' ? (
-                    <Dh.TextRecord>상반기 히스토그램을 확인해 보세요!</Dh.TextRecord>
-                ) : location.pathname === '/insightchart' ? (
-                    <Dh.TextRecord>월별 히스토그램을 확인해 보세요!</Dh.TextRecord>
-                ) : (
-                    <>
-                        <Dh.Title>나의 AI 파트너, WIDER와</Dh.Title>
-                        <Dh.Text>오늘의 대화를 시작해 보세요!</Dh.Text>
-                    </>
-                )}
+                <Dh.TextWrapper>
+                    {location.pathname.startsWith('/record') ? (
+                        <Dh.TextRecord>리포트 기록을 확인해 보세요!</Dh.TextRecord>
+                    ) : location.pathname === '/insight' ? (
+                        <Dh.TextRecord>
+                            WIDER와 함께한 사고 연습,
+                            <br /> 그동안의 레벨 변화는 어땠을까요?
+                        </Dh.TextRecord>
+                    ) : location.pathname === '/insightchart' ? (
+                        <Dh.TextRecord>
+                            WIDER와 함께한 이번 달 사고 연습, <br /> 내 사고 레벨은 어디쯤일까요?
+                        </Dh.TextRecord>
+                    ) : location.pathname === '/setting' ? (
+                        <Dh.TextRecord>나의 계정 정보를 확인해 보세요!</Dh.TextRecord>
+                    ) : (
+                        <>
+                            <Dh.Title>나의 AI 파트너, WIDER와</Dh.Title>
+                            <Dh.Text>오늘의 대화를 시작해 보세요!</Dh.Text>
+                        </>
+                    )}
+                </Dh.TextWrapper>
             </Dh.Body>
             {location.pathname === '/chat' && (
                 <Dh.Report onClick={goToReport}>

--- a/src/components/header/HomeDeskHeaderStyles.jsx
+++ b/src/components/header/HomeDeskHeaderStyles.jsx
@@ -31,11 +31,23 @@ export const Body = styled.div`
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 5px;
     color: #4e4e4e;
     font-size: 18px;
-    padding: 15px 30px;
     font-weight: bold;
+`;
+
+export const TextWrapper = styled.div`
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    width: 100%;
+    z-index: 1;
 `;
 
 export const BackgroundImg = styled.img`
@@ -56,6 +68,25 @@ export const Title = styled.div`
 export const Text = styled.div`
     position: relative;
     z-index: 1;
+`;
+
+export const Report = styled.div`
+    img {
+        width: 70px;
+        height: 70px;
+    }
+    margin-left: auto;
+    margin-right: 50px;
+    cursor: pointer;
+`;
+
+export const TextRecord = styled.div`
+    font-weight: bold;
+    font-size: 18px;
+    color: #4e4e4e;
+    z-index: 1;
+    position: relative;
+    text-align: center;
 `;
 
 export const Report = styled.div`

--- a/src/components/header/SettingsHeader.jsx
+++ b/src/components/header/SettingsHeader.jsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { changePassword, serverLogout, logout, deleteUser } from '../../store/userSlice';
 import * as Sh from './SettingsHeaderStyles.jsx';
 import Logo from '../../assets/LogoIcon.png';
 import Rectangle from '../../assets/Rectangle.svg';
@@ -7,33 +9,230 @@ import Setting from '../../assets/Setting.png';
 
 const SettingsHeader = () => {
     const location = useLocation();
+    const user = useSelector((state) => state.user);
+    const [showDropdown, setShowDropdown] = useState(false);
+    const [showPasswordBox, setShowPasswordBox] = useState(false);
+    const [passwords, setPasswords] = useState({
+        current_password: '',
+        new_password1: '',
+        new_password2: '',
+    });
+    const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+
+    const dispatch = useDispatch();
+    const token = useSelector((state) => state.user.token);
+
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [deleteForm, setDeleteForm] = useState({
+        user_id: '',
+        password: '',
+    });
 
     const titleText =
         location.pathname === '/insight'
-            ? '상반기 히스토그램을 확인 해 보세요!'
+            ? 'WIDER와 함께한 사고 연습,\n그동안의 레벨 변화는 어땠을까요?'
             : location.pathname === '/insightchart'
-            ? '월별 히스토그램을 확인해 보세요!'
+            ? 'WIDER와 함께한 이번 달 사고 연습,\n내 사고 레벨은 어디쯤일까요?'
             : '리포트 기록을 확인해 보세요!';
 
+    const toggleDropdown = () => {
+        setShowDropdown((prev) => !prev);
+    };
+
+    const goToTermsPage = () => {
+        navigate('/termspage');
+    };
+
+    const handlePasswordChangeClick = () => {
+        setShowDropdown(false);
+        setShowPasswordBox(true);
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setPasswords((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    };
+
+    const handleSubmitPasswordChange = async () => {
+        console.log('현재 전달되는 토큰:', token);
+        console.log('currentPassword:', passwords.current_password);
+        console.log('newPassword1:', passwords.new_password1);
+        console.log('newPassword2:', passwords.new_password2);
+
+        try {
+            const passwordData = {
+                current_password: passwords.current_password,
+                new_password1: passwords.new_password1,
+                new_password2: passwords.new_password2,
+            };
+
+            console.log('비번 변경 요청에 사용할 토큰:', token);
+
+            const resultAction = await dispatch(changePassword({ passwordData, token }));
+
+            if (changePassword.fulfilled.match(resultAction)) {
+                alert('비밀번호가 성공적으로 변경되었습니다.');
+                setShowPasswordBox(false);
+                setPasswords({
+                    current_password: '',
+                    new_password1: '',
+                    new_password2: '',
+                });
+            } else {
+                alert(resultAction.payload?.message || '비밀번호 변경 실패');
+            }
+        } catch (e) {
+            alert('알 수 없는 에러가 발생했습니다.');
+        }
+    };
+
+    const handleLogoutClick = () => {
+        setShowDropdown(false);
+        setShowLogoutConfirm(true);
+    };
+
+    const confirmLogout = async () => {
+        try {
+            await dispatch(serverLogout(token));
+            dispatch(logout());
+            navigate('/');
+        } catch (e) {
+            alert('로그아웃 실패');
+        }
+    };
+
+    const cancelLogout = () => {
+        setShowLogoutConfirm(false);
+    };
+
+    const handleDeleteInputChange = (e) => {
+        const { name, value } = e.target;
+        setDeleteForm((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    };
+
+    const handleConfirmDelete = async () => {
+        if (!deleteForm.user_id || !deleteForm.password) {
+            alert('아이디와 비밀번호를 입력해주세요.');
+            return;
+        }
+
+        try {
+            await dispatch(deleteUser(deleteForm));
+            dispatch(logout());
+            navigate('/');
+        } catch (e) {
+            alert('회원 탈퇴 실패');
+        }
+    };
+
     return (
-        <Sh.Container>
-            <Sh.Left>
-                <Sh.Logo>
-                    <img src={Logo} />
-                </Sh.Logo>
-                <Sh.Title>
-                    <Sh.Rectangle>
-                        <img src={Rectangle} />
-                    </Sh.Rectangle>
-                    <Sh.TitleText>{titleText}</Sh.TitleText>
-                </Sh.Title>
-            </Sh.Left>
-            <Sh.Right>
-                <Sh.Setting>
-                    <img src={Setting} />
-                </Sh.Setting>
-            </Sh.Right>
-        </Sh.Container>
+        <>
+            <Sh.Container>
+                <Sh.Left>
+                    <Sh.Logo>
+                        <img src={Logo} />
+                    </Sh.Logo>
+                    <Sh.Title>
+                        <Sh.Rectangle>
+                            <img src={Rectangle} />
+                        </Sh.Rectangle>
+                        <Sh.TitleText>{titleText}</Sh.TitleText>
+                    </Sh.Title>
+                </Sh.Left>
+                <Sh.Right>
+                    <Sh.Setting onClick={toggleDropdown}>
+                        <img src={Setting} />
+                    </Sh.Setting>
+                </Sh.Right>
+            </Sh.Container>
+            {showDropdown && (
+                <Sh.DropdownBox>
+                    <Sh.SectionTitle>계정</Sh.SectionTitle>
+                    <Sh.ItemRow nonHover>
+                        <span>아이디</span> <span style={{ color: '#aaa' }}>{user.id}</span>
+                    </Sh.ItemRow>
+                    <Sh.ItemRow onClick={handlePasswordChangeClick}>비밀번호 변경</Sh.ItemRow>
+                    <Sh.ItemRow>채팅 알림 기능</Sh.ItemRow>
+                    <Sh.SectionTitle>서비스</Sh.SectionTitle>
+                    <Sh.ItemRow onClick={goToTermsPage}>서비스 이용 약관</Sh.ItemRow>
+                    <Sh.ItemRow onClick={handleLogoutClick}>로그아웃</Sh.ItemRow>
+                    <Sh.ItemRow
+                        onClick={() => {
+                            setShowDropdown(false);
+                            setShowDeleteConfirm(true);
+                        }}
+                    >
+                        회원탈퇴
+                    </Sh.ItemRow>
+                </Sh.DropdownBox>
+            )}
+            {showPasswordBox && (
+                <Sh.PasswordOverlay>
+                    <Sh.PasswordBox>
+                        <Sh.Input
+                            type="password"
+                            name="current_password"
+                            placeholder="현재 비밀번호"
+                            value={passwords.current_password}
+                            onChange={handleInputChange}
+                        />
+                        <Sh.Input
+                            type="password"
+                            name="new_password1"
+                            placeholder="새 비밀번호"
+                            value={passwords.new_password1}
+                            onChange={handleInputChange}
+                        />
+                        <Sh.Input
+                            type="password"
+                            name="new_password2"
+                            placeholder="새 비밀번호 확인"
+                            value={passwords.new_password2}
+                            onChange={handleInputChange}
+                        />
+                        <Sh.SubmitButton onClick={handleSubmitPasswordChange}>변경하기</Sh.SubmitButton>
+                    </Sh.PasswordBox>
+                </Sh.PasswordOverlay>
+            )}
+            {showLogoutConfirm && (
+                <Sh.PasswordOverlay>
+                    <Sh.PasswordBox>
+                        <Sh.ConfirmText>정말 로그아웃하시겠습니까?</Sh.ConfirmText>
+                        <Sh.LogoutButton onClick={confirmLogout}>확인</Sh.LogoutButton>
+                        <Sh.LogoutButton onClick={cancelLogout}>취소</Sh.LogoutButton>
+                    </Sh.PasswordBox>
+                </Sh.PasswordOverlay>
+            )}
+            {showDeleteConfirm && (
+                <Sh.PasswordOverlay>
+                    <Sh.PasswordBox>
+                        <Sh.ConfirmText>정말 탈퇴하시겠습니까?</Sh.ConfirmText>
+                        <Sh.Input
+                            type="text"
+                            name="user_id"
+                            placeholder="아이디 입력"
+                            value={deleteForm.user_id}
+                            onChange={handleDeleteInputChange}
+                        />
+                        <Sh.Input
+                            type="password"
+                            name="password"
+                            placeholder="비밀번호 입력"
+                            value={deleteForm.password}
+                            onChange={handleDeleteInputChange}
+                        />
+                        <Sh.LogoutButton onClick={handleConfirmDelete}>탈퇴 확인</Sh.LogoutButton>
+                        <Sh.LogoutButton onClick={() => setShowDeleteConfirm(false)}>취소</Sh.LogoutButton>
+                    </Sh.PasswordBox>
+                </Sh.PasswordOverlay>
+            )}
+        </>
     );
 };
 export default SettingsHeader;

--- a/src/components/header/SettingsHeaderStyles.jsx
+++ b/src/components/header/SettingsHeaderStyles.jsx
@@ -60,6 +60,7 @@ export const TitleText = styled.div`
     white-space: nowrap;
     margin-left: -90px;
     z-index: 1;
+    white-space: pre-line;
 `;
 
 export const Right = styled.div`
@@ -73,5 +74,107 @@ export const Setting = styled.div`
     img {
         width: 45px;
         height: 45px;
+    }
+    cursor: pointer;
+    position: relative;
+`;
+
+export const DropdownBox = styled.div`
+    position: absolute;
+    top: 80px;
+    right: 20px;
+    width: 260px;
+    background: #fff;
+    border-radius: 20px;
+    padding: 20px;
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.15);
+    z-index: 10;
+`;
+
+export const SectionTitle = styled.div`
+    font-weight: bold;
+    margin-bottom: 10px;
+    margin-top: 10px;
+`;
+
+export const ItemRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    padding: 12px 16px;
+    font-size: 14px;
+    cursor: pointer;
+
+    ${({ nonHover }) =>
+        !nonHover &&
+        `
+        &:hover {
+            background-color: #f2f2f2;
+            border-radius: 10px;
+        }
+    `}
+`;
+
+export const PasswordOverlay = styled.div`
+    position: absolute;
+    top: 80px;
+    right: 20px;
+    width: 280px;
+    background-color: white;
+    border-radius: 16px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    z-index: 999;
+    padding: 20px;
+`;
+
+export const PasswordBox = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+`;
+
+export const Input = styled.input`
+    padding: 12px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    font-size: 14px;
+    &:focus {
+        outline: none;
+        border: 2px solid #6ba9ec;
+    }
+`;
+
+export const SubmitButton = styled.button`
+    padding: 10px;
+    background-color: #6ba9ec;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+
+    &:hover {
+        background-color: #4091e8;
+    }
+`;
+
+export const ConfirmText = styled.div`
+    text-align: center;
+    font-size: 20px;
+    margin-bottom: 10px;
+    margin-top: 10px;
+`;
+
+export const LogoutButton = styled.button`
+    padding: 10px;
+    width: 80%;
+    margin: 0 auto;
+    background-color: #6ba9ec;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    margin-top: 5px;
+
+    &:hover {
+        background-color: #4091e8;
     }
 `;

--- a/src/pages/setting/Setting.jsx
+++ b/src/pages/setting/Setting.jsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { serverLogout, logout, deleteUser, changePassword } from '../../store/userSlice';
+import * as S from './SettingStyles.jsx';
+import HomeDeskHeader from '../../components/header/HomeDeskHeader.jsx';
+import Sidebar from '../../components/sidebar/Sidebar.jsx';
+
+const Setting = () => {
+    const navigate = useNavigate();
+    const user = useSelector((state) => state.user);
+    const [showPasswordBox, setShowPasswordBox] = useState(false);
+    const [passwords, setPasswords] = useState({
+        current_password: '',
+        new_password1: '',
+        new_password2: '',
+    });
+    const dispatch = useDispatch();
+    const token = useSelector((state) => state.user.token);
+    const [deleteId, setDeleteId] = useState('');
+    const [deletePassword, setDeletePassword] = useState('');
+    const [showDeleteBox, setShowDeleteBox] = useState(false);
+
+    const goToTermsPage = () => {
+        navigate('/termspage');
+    };
+
+    const togglePasswordBox = () => {
+        setShowPasswordBox((prev) => !prev);
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setPasswords((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    };
+
+    const handleLogout = async () => {
+        const confirmed = window.confirm('정말 로그아웃하시겠습니까?');
+        if (!confirmed) return;
+
+        try {
+            await dispatch(serverLogout(token));
+            dispatch(logout());
+            navigate('/');
+        } catch (e) {
+            alert('로그아웃 실패');
+        }
+    };
+
+    const handleDelete = async () => {
+        const confirmed = window.confirm('정말 탈퇴하시겠습니까? 이 작업은 되돌릴 수 없습니다.');
+        if (!confirmed) return;
+
+        try {
+            await dispatch(deleteUser({ user_id: user.id, password: deletePassword }));
+            dispatch(logout());
+            navigate('/');
+        } catch (e) {
+            alert('회원 탈퇴 실패: ' + (e?.message || ''));
+        }
+    };
+
+    const handleSubmitPasswordChange = async () => {
+        try {
+            const passwordData = {
+                current_password: passwords.current_password,
+                new_password1: passwords.new_password1,
+                new_password2: passwords.new_password2,
+            };
+
+            const resultAction = await dispatch(changePassword({ passwordData, token }));
+
+            if (changePassword.fulfilled.match(resultAction)) {
+                alert('비밀번호가 성공적으로 변경되었습니다.');
+                setPasswords({
+                    current_password: '',
+                    new_password1: '',
+                    new_password2: '',
+                });
+                setShowPasswordBox(false);
+            } else {
+                alert(resultAction.payload?.message || '비밀번호 변경 실패');
+            }
+        } catch (e) {
+            alert('알 수 없는 에러가 발생했습니다.');
+        }
+    };
+
+    return (
+        <S.Container>
+            <HomeDeskHeader />
+            <S.Content>
+                <S.Section>
+                    <S.SectionTitle>계정</S.SectionTitle>
+                    <S.Box>
+                        <S.ItemRow $nonHover>
+                            <span>아이디</span>
+                            <span style={{ color: '#aaa' }}>{user.id}</span>
+                        </S.ItemRow>
+                        <S.ItemRow onClick={togglePasswordBox}>비밀번호 변경</S.ItemRow>
+                        {showPasswordBox && (
+                            <S.PasswordBox>
+                                <S.PasswordInput
+                                    type="password"
+                                    name="current_password"
+                                    placeholder="현재 비밀번호"
+                                    value={passwords.current_password}
+                                    onChange={handleInputChange}
+                                />
+                                <S.PasswordInput
+                                    type="password"
+                                    name="new_password1"
+                                    placeholder="새 비밀번호"
+                                    value={passwords.new_password1}
+                                    onChange={handleInputChange}
+                                />
+                                <S.PasswordInput
+                                    type="password"
+                                    name="new_password2"
+                                    placeholder="새 비밀번호 확인"
+                                    value={passwords.new_password2}
+                                    onChange={handleInputChange}
+                                />
+                                <S.SubmitButton onClick={handleSubmitPasswordChange}>변경하기</S.SubmitButton>
+                            </S.PasswordBox>
+                        )}
+                    </S.Box>
+                </S.Section>
+                <S.Section>
+                    <S.SectionTitle>서비스</S.SectionTitle>
+                    <S.Box>
+                        <S.ItemRow onClick={goToTermsPage}>서비스 이용 약관</S.ItemRow>
+                        <S.ItemRow onClick={handleLogout}>로그아웃</S.ItemRow>
+                        <S.ItemRow onClick={() => setShowDeleteBox(true)}>회원 탈퇴</S.ItemRow>
+                        {showDeleteBox && (
+                            <S.PasswordBox>
+                                <S.PasswordInput
+                                    type="text"
+                                    placeholder="아이디 입력"
+                                    value={deleteId}
+                                    onChange={(e) => setDeleteId(e.target.value)}
+                                />
+                                <S.PasswordInput
+                                    type="password"
+                                    placeholder="비밀번호 입력"
+                                    value={deletePassword}
+                                    onChange={(e) => setDeletePassword(e.target.value)}
+                                />
+                                <S.SubmitButton onClick={handleDelete}>탈퇴하기</S.SubmitButton>
+                            </S.PasswordBox>
+                        )}
+                    </S.Box>
+                </S.Section>
+            </S.Content>
+            <Sidebar />
+        </S.Container>
+    );
+};
+export default Setting;


### PR DESCRIPTION
# [feature/header] 설정 페이지 비밀번호 변경·로그아웃·회원탈퇴 기능 구현 및 채팅에서 리포트로 sessionId 전달

## PR요약

해당 pr은
-   채팅 페이지에서 생성된 sessionId를 리포트 페이지로 전달하여 해당 세션의 리포트를 확인할 수 있도록 구현했습니다.
-   설정 페이지에서 비밀번호 변경, 로그아웃, 회원탈퇴 기능을 API 연동과 함께 구현하였고, 각 동작을 위한 모달 및 입력창 UI를 추가했습니다.

## 관련 이슈

해당 작업은 설정 기능 개선 및 리포트 연결 흐름 개발을 위한 신규 기능입니다.

## 작업 내용

-   `HomeDeskHeader.jsx`, `HomeDeskHeaderStyles.jsx`
    -   채팅 페이지에서 sessionId를 전달받아 리포트 페이지로 네이게이션 시 함께 넘기도록 구현
    -   `/insight`, `/insightchart`, `/setting` 등 경로에 따라 안내 문구 다르게 출력되도록 조건 분기 추가
-   `SettingsHeader.jsx`, `SettingsHeaderStyles.jsx`, `Setting.jsx`
    -   비밀번호 변경 기능 구현 (`changePassword` API 연동)
    -   로그아웃 기능 구현 (`serverLogout` 및 상태 초기화 처리)
    -   회원탈퇴 기능 구현 (`deleteUser` 연동 및 confirm 입력 처리)
    -   모달 및 입력창 UI 구성: 오버레이 레이어를 통한 사용자 상호작용 지원

## 공유사항

-   `sessionId` 전달 구조가 바뀔 경우 리포트 페이지와의 연결 로직도 함께 수정 필요합니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
