### PR TITLE
[fix] HomeDeskHeaderStyles.jsx에서 Report, TextRecord 중복 선언 제거로 빌드 오류 해결

### DIFF
--- a/src/components/header/HomeDeskHeaderStyles.jsx
+++ b/src/components/header/HomeDeskHeaderStyles.jsx
@@ -88,22 +88,3 @@ export const TextRecord = styled.div`
     position: relative;
     text-align: center;
 `;
-
-export const Report = styled.div`
-    img {
-        width: 70px;
-        height: 70px;
-    }
-    margin-left: auto;
-    margin-right: 50px;
-    cursor: pointer;
-`;
-
-export const TextRecord = styled.div`
-    font-weight: bold;
-    font-size: 18px;
-    color: #4e4e4e;
-    z-index: 1;
-    position: relative;
-    text-align: center;
-`;


### PR DESCRIPTION
# [feature/header] HomeDeskHeaderStyles.jsx에서 Report, TextRecord 중복 선언 제거로 빌드 오류 해결

## PR요약

해당 pr은
-   Vercel 빌드 오류를 해결하기 위해 `HomeDeskHeaderStyles.jsx` 내 중복 선언된 `Report`, `TextRecord` 식별자를 제거한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `HomeDeskHeaderStyles.jsx`에서 `Report`, `TextRecord`가 각각 import와 styled-component로 중복 선언되어 있어 빌드 에러 발생
-   중복 선언된 styled-component 제거하여 충돌 해소

## 트러블 슈팅

-   문제 원인: 동일한 이름의 식별자를 중복 선언하면서 SyntaxError 발생 (`Identifier 'Report' has already been declared`)
-   해결 방식: 하나의 선언을 제거하거나 변수명을 변경하여 충돌 해결

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
