### PR TITLE
[feat] getChatHistoryApi 연동으로 채팅 기록 조회 기능 추가 및 중복 전송 오류 수정

### DIFF
--- a/src/api/chat/ChatApi.js
+++ b/src/api/chat/ChatApi.js
@@ -31,3 +31,12 @@ export const endChatApi = async (token, payload) => {
     });
     return response.data;
 };
+
+export const getChatHistoryApi = async (sessionId, token) => {
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/api/chat/history/${sessionId}`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return response.data;
+};


### PR DESCRIPTION
# [feature/chat] getChatHistoryApi 연동으로 채팅 기록 조회 기능 추가 및 중복 전송 오류 수정

## PR요약

해당 pr은
-   기존 채팅 화면(`ChatScreen`, `ChatDeskScreen`)에서 채팅 세션 기록을 불러오는 기능을 추가하고, 답변 입력 시 마지막 메시지가 중복으로 전송되는 오류를 수정한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `ChatApi.js`에 `getChatHistoryApi` 함수 추가
    -   백엔드에서 제공하는 `/api/chat/history/{session_id}` API 연동
    -   세션 ID로 과거 대화 기록을 불러오는 기능 구현
-   `ChatScreen.jsx`, `ChatDeskScreen.jsx`에 기존 채팅 세션 기록 불러오는 로직 추가
    -   `location.state.sessionId`가 있을 경우 기록 로드
    -   불러온 메시지를 포맷에 맞게 변환하여 UI에 출력
-   답변 입력 시 마지막 메시지가 한 번 더 전송되는 현상 수정
    -   `setUserAnswer('')` 호출 타이밍 조정

## 공유사항

-   동일한 채팅 컴포넌트가 데스크탑과 모바일 각각 존재하여 두 화면 모두에 동일한 로직을 적용했습니다.
-   현재 백엔드에서 응답 에러로 인해 `getChatHistoryApi` 결과 확인은 불가능한 상태이며, 백엔드 정상화 이후 추가 확인이 필요합니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
