### PR TITLE
[build] manifest.json에 purpose: "any" 추가로 iOS 홈화면 아이콘 렌더링 문제 해결

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,37 +5,44 @@
         {
             "src": "logo_icon-48x48.png",
             "sizes": "48x48",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "logo_icon-72x72.png",
             "sizes": "72x72",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "logo_icon-96x96.png",
             "sizes": "96x96",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "logo_icon-128x128.png",
             "sizes": "128x128",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "logo_icon-192x192.png",
             "type": "image/png",
-            "sizes": "192x192"
+            "sizes": "192x192",
+            "purpose": "any"
         },
         {
             "src": "logo_icon-384x384.png",
             "sizes": "384x384",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "any"
         },
         {
             "src": "logo_icon-512x512.png",
             "type": "image/png",
-            "sizes": "512x512"
+            "sizes": "512x512",
+            "purpose": "any"
         }
     ],
     "start_url": ".",


### PR DESCRIPTION
# [build/vercel-deploy] manifest.json에 purpose: "any" 추가로 iOS 홈화면 아이콘 렌더링 문제 해결

## PR요약

해당 pr은
-   iOS 홈 화면에 PWA를 추가할 때 아이콘 배경이 검정색으로 표시되는 문제를 해결하기 위해 `manifest.json`의 모든 아이콘에 `purpose: "any"` 속성을 추가한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `manifest.json` 내 모든 아이콘 항목에 `"purpose": "any"` 속성 추가
    -   iOS Safari가 아이콘의 원래 디자인을 그대로 사용하도록 지정
-   배경이 흰색으로 포함된 아이콘 이미지와 호환되도록 설정
-   아이콘 렌더링 오류(검정 배경 포함 등) 방지를 위해 PWA 메타데이터 개선

## 트러블슈팅

-   문제: iOS에서 홈 화면에 추가 시 아이콘 테두리에 불필요한 검은 배경이 표시됨
-   해결: 아이콘의 `"purpose"`를 명시하지 않으면 iOS가 자동으로 마스킹 처리함 → `"purpose": "any"`로 변경하여 원본 이미지 유지

## 공유사항

-   수정된 사항은 실제 iOS 기기에서 테스트 필요
-   일부 캐싱 문제로 변경 사항 반영까지 시간이 걸릴 수 있으니, 아이콘 변경 후 앱 삭제 및 Safari 캐시 삭제 후 테스트 권장

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
