### PR TITLE
[feat] 홈 화면에서 채팅 진입 시 세션 ID 전달 로직 추가

### DIFF
--- a/src/pages/home/HomeDeskScreen.jsx
+++ b/src/pages/home/HomeDeskScreen.jsx
@@ -12,7 +12,12 @@ const HomeDesk = () => {
     const [todayTopic, setTodayTopic] = useState('');
 
     const goToChat = () => {
-        navigate('/chat');
+        const sessionId = localStorage.getItem('latest_session_id');
+        if (sessionId) {
+            navigate('/chat', { state: { sessionId } });
+        } else {
+            navigate('/chat');
+        }
     };
 
     const goToReport = () => {

--- a/src/pages/home/HomeScreen.jsx
+++ b/src/pages/home/HomeScreen.jsx
@@ -15,7 +15,12 @@ const Home = () => {
     const [todayTopic, setTodayTopic] = useState('');
 
     const goToChat = () => {
-        navigate('/chat');
+        const sessionId = localStorage.getItem('latest_session_id');
+        if (sessionId) {
+            navigate('/chat', { state: { sessionId } });
+        } else {
+            navigate('/chat');
+        }
     };
 
     const goToReport = () => {


### PR DESCRIPTION
# [feature/home] 홈 화면에서 채팅 진입 시 세션 ID 전달 로직 추가

## PR요약

해당 pr은
-   홈 화면(HomeScreen, HomeDeskScreen)에서 채팅 화면으로 진입할 때 로컬 스토리지에 저장된 `latest_session_id`를 함께 전달하도록 로직을 추가한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `HomeScreen.jsx`, `HomeDeskScreen.jsx` 파일 수정
    -   `navigate('/chat', { state: { sessionId} })` 형식으로 세션 ID를 전달
-   세션 ID가 없을 경우에는 기존처럼 새로운 대화 시작을 위해 빈 상태로 채팅 화면 이동 처리

## 공유사항

-   추후 채팅 화면에서는 전달받은 세션 ID를 바탕으로 `getChatHistoryApi` 또는 `startChatApi`를 분기 처리하게 됩니다.
-   해당 로직은 이미 ChatDeskScreen, ChatScreen 쪽에서 구현 완료되어 있습니다.
-   테스트 시 `localStorage.setItem('latest_session_id', 세션아이디값)`으로 세션 ID를 먼저 저장해 두고 이동해 보면 됩니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
