### PR TITLE
[feat] 채팅 기록 API 연동 및 화면 구현

### DIFF
--- a/src/api/chatRecord/RecordApi.js
+++ b/src/api/chatRecord/RecordApi.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export const getRecordListApi = async (token) => {
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/api/records`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return response.data;
+};

--- a/src/pages/chatRecord/RecordDate.jsx
+++ b/src/pages/chatRecord/RecordDate.jsx
@@ -1,66 +1,67 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getRecordListApi } from '../../api/chatRecord/RecordApi';
 import * as Rd from './RecordDateStyles.jsx';
 import Header from '../../components/header/SettingsHeader';
 import Footer from '../../components/footer/Footer';
 
 const RecordDate = () => {
     const navigate = useNavigate();
+    const token = useSelector((state) => state.user.token);
+    const [recordList, setRecordList] = useState([]);
+
+    useEffect(() => {
+        const fetchRecords = async () => {
+            try {
+                const res = await getRecordListApi(token);
+                console.log('기록 목록 API 응답:', res);
+                setRecordList(res.records || res);
+            } catch (err) {
+                console.error('기록 목록 불러오기 실패:', err);
+            }
+        };
+        fetchRecords();
+    }, [token]);
+
+    const formatDate = (isoString) => {
+        const date = new Date(isoString);
+        const yyyy = date.getFullYear();
+        const mm = String(date.getMonth() + 1).padStart(2, '0');
+        const dd = String(date.getDate()).padStart(2, '0');
+        return `${yyyy}\n${mm}/${dd}`;
+    };
 
     return (
         <Rd.Container>
             <Header />
+            {/* <Rd.Content>
+                {recordList.map((record) => (
+                    <Rd.CategoryContent
+                        key={record.session_id}
+                        onClick={() => navigate(`/report`, { state: { sessionId: record.session_id } })}
+                    >
+                        <Rd.CategoryDate>{formatDate(record.started_at)}</Rd.CategoryDate>
+                        <Rd.ContentTitle>{record.topic}</Rd.ContentTitle>
+                        <Rd.BloomLevel>Level {record.bloom_level}</Rd.BloomLevel>
+                    </Rd.CategoryContent>
+                ))}
+            </Rd.Content> */}
             <Rd.Content>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025
-                        <br />
-                        03/25
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>공휴일 확대가 국가 경제에 도움이 될까?</Rd.ContentTitle>
-                </Rd.CategoryContent>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025 <br />
-                        03/24
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>주 4일제 근무에 대해 어떻게 생각하세요?</Rd.ContentTitle>
-                </Rd.CategoryContent>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025 <br />
-                        03/23
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>AI는 정말로 사람의 일자리를 뺏을까?</Rd.ContentTitle>
-                </Rd.CategoryContent>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025 <br />
-                        03/22
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>딥시크 사태는 글로벌 AI 산업에 어떤 영향을 미쳤을까?</Rd.ContentTitle>
-                </Rd.CategoryContent>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025 <br />
-                        03/21
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>인공지능의 발전이 교육 방식에 어떤 변화를 가져올까?</Rd.ContentTitle>
-                </Rd.CategoryContent>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025 <br />
-                        03/20
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>디지털 기술이 인간관계에 미치는 영향은 긍정적일까?</Rd.ContentTitle>
-                </Rd.CategoryContent>
-                <Rd.CategoryContent>
-                    <Rd.CategoryDate>
-                        2025 <br />
-                        03/19
-                    </Rd.CategoryDate>
-                    <Rd.ContentTitle>청년층의 정치 참여를 높이기 위한 방안은 무엇일까?</Rd.ContentTitle>
-                </Rd.CategoryContent>
+                {recordList.length === 0 ? (
+                    <Rd.EmptyMessage>기록된 내용이 없습니다.</Rd.EmptyMessage>
+                ) : (
+                    recordList.map((record) => (
+                        <Rd.CategoryContent
+                            key={record.session_id}
+                            onClick={() => navigate(`/report`, { state: { sessionId: record.session_id } })}
+                        >
+                            <Rd.CategoryDate>{formatDate(record.started_at)}</Rd.CategoryDate>
+                            <Rd.ContentTitle>{record.topic}</Rd.ContentTitle>
+                            <Rd.BloomLevel>Level {record.bloom_level}</Rd.BloomLevel>
+                        </Rd.CategoryContent>
+                    ))
+                )}
             </Rd.Content>
             <Footer />
         </Rd.Container>

--- a/src/pages/chatRecord/RecordDateDesk.jsx
+++ b/src/pages/chatRecord/RecordDateDesk.jsx
@@ -1,69 +1,57 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getRecordListApi } from '../../api/chatRecord/RecordApi';
 import * as R from './RecordDateDeskStyles.jsx';
 import HomeDeskHeader from '../../components/header/HomeDeskHeader';
 import Sidebar from '../../components/sidebar/Sidebar';
 
-const RecordDate = () => {
+const RecordDateDesk = () => {
     const navigate = useNavigate();
+    const token = useSelector((state) => state.user.token);
+    const [recordList, setRecordList] = useState([]);
+
+    useEffect(() => {
+        const fetchRecords = async () => {
+            try {
+                const res = await getRecordListApi(token);
+                setRecordList(res);
+            } catch (err) {
+                console.error('기록 목록 불러오기 실패:', err);
+            }
+        };
+        fetchRecords();
+    }, [token]);
+
+    const formatDate = (isoString) => {
+        const date = new Date(isoString);
+        const yyyy = date.getFullYear();
+        const mm = String(date.getMonth() + 1).padStart(2, '0');
+        const dd = String(date.getDate()).padStart(2, '0');
+        return `${yyyy}\n${mm}/${dd}`;
+    };
 
     return (
         <R.Container>
             <HomeDeskHeader />
             <R.Content>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025
-                        <br />
-                        03/25
-                    </R.CategoryDate>
-                    <R.ContentTitle>공휴일 확대가 국가 경제에 도움이 될까?</R.ContentTitle>
-                </R.CategoryContent>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025 <br />
-                        03/24
-                    </R.CategoryDate>
-                    <R.ContentTitle>주 4일제 근무에 대해 어떻게 생각하세요?</R.ContentTitle>
-                </R.CategoryContent>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025 <br />
-                        03/23
-                    </R.CategoryDate>
-                    <R.ContentTitle>AI는 정말로 사람의 일자리를 뺏을까?</R.ContentTitle>
-                </R.CategoryContent>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025 <br />
-                        03/22
-                    </R.CategoryDate>
-                    <R.ContentTitle>딥시크 사태는 글로벌 AI 산업에 어떤 영향을 미쳤을까?</R.ContentTitle>
-                </R.CategoryContent>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025 <br />
-                        03/21
-                    </R.CategoryDate>
-                    <R.ContentTitle>인공지능의 발전이 교육 방식에 어떤 변화를 가져올까?</R.ContentTitle>
-                </R.CategoryContent>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025 <br />
-                        03/20
-                    </R.CategoryDate>
-                    <R.ContentTitle>디지털 기술이 인간관계에 미치는 영향은 긍정적일까?</R.ContentTitle>
-                </R.CategoryContent>
-                <R.CategoryContent>
-                    <R.CategoryDate>
-                        2025 <br />
-                        03/19
-                    </R.CategoryDate>
-                    <R.ContentTitle>청년층의 정치 참여를 높이기 위한 방안은 무엇일까?</R.ContentTitle>
-                </R.CategoryContent>
+                {recordList.length === 0 ? (
+                    <R.EmptyMessage>기록된 내용이 없습니다.</R.EmptyMessage>
+                ) : (
+                    recordList.map((record) => (
+                        <R.CategoryContent
+                            key={record.session_id}
+                            onClick={() => navigate(`/report`, { state: { sessionId: record.session_id } })}
+                        >
+                            <R.CategoryDate>{formatDate(record.started_at)}</R.CategoryDate>
+                            <R.ContentTitle>{record.topic}</R.ContentTitle>
+                            <R.BloomLevel>Level {record.bloom_level}</R.BloomLevel>
+                        </R.CategoryContent>
+                    ))
+                )}
             </R.Content>
             <Sidebar />
         </R.Container>
     );
 };
-export default RecordDate;
+export default RecordDateDesk;

--- a/src/pages/chatRecord/RecordDateDeskStyles.jsx
+++ b/src/pages/chatRecord/RecordDateDeskStyles.jsx
@@ -18,7 +18,7 @@ export const Container = styled.div`
 export const Content = styled.div`
     flex: 1;
     overflow-y: auto;
-    width: 90%;
+    width: 85%;
     margin-top: 0px;
     display: flex;
     flex-direction: column;
@@ -32,19 +32,41 @@ export const CategoryContent = styled.div`
     align-items: center;
     background-color: #e6e4e4;
     border-radius: 20px;
-    padding: 20px 15px;
+    padding: 25px 40px;
     color: #383636;
     font-weight: bold;
 `;
 
 export const CategoryDate = styled.div`
-    font-size: 16px;
-    margin-right: 10px;
+    font-size: 18px;
+    margin-right: 30px;
     white-space: nowrap;
 `;
 
+export const TitleWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+`;
+
 export const ContentTitle = styled.div`
-    font-size: 16px;
+    font-size: 18px;
     text-align: left;
     word-break: keep-all;
+`;
+
+export const BloomLevel = styled.div`
+    font-size: 18px;
+    color: #383636;
+    font-weight: bold;
+    margin-bottom: 1px;
+    margin-right: 10px;
+`;
+
+export const EmptyMessage = styled.div`
+    font-size: 18px;
+    color: #888;
+    margin-top: 50px;
+    text-align: center;
 `;

--- a/src/pages/chatRecord/RecordDateStyles.jsx
+++ b/src/pages/chatRecord/RecordDateStyles.jsx
@@ -24,7 +24,6 @@ export const Content = styled.div`
     flex-direction: column;
     gap: 25px;
     border-radius: 20px;
-    /* padding: 15px; */
     padding: 100px 15px 130px;
 `;
 export const CategoryContent = styled.div`
@@ -33,7 +32,7 @@ export const CategoryContent = styled.div`
     align-items: center;
     background-color: #e6e4e4;
     border-radius: 20px;
-    padding: 20px 15px;
+    padding: 20px 45px;
     color: #383636;
     font-weight: bold;
 `;
@@ -48,4 +47,19 @@ export const ContentTitle = styled.div`
     font-size: 16px;
     text-align: left;
     word-break: keep-all;
+    margin-right: 10px;
+`;
+
+export const BloomLevel = styled.div`
+    font-size: 17px;
+    color: #383636;
+    font-weight: bold;
+    margin-bottom: 1px;
+`;
+
+export const EmptyMessage = styled.div`
+    font-size: 16px;
+    color: #888;
+    margin-top: 50px;
+    text-align: center;
 `;


### PR DESCRIPTION
# [feature/record] 채팅 기록 API 연동 및 화면 구현

## PR요약

해당 pr은
-   기존에 구현되어 있던 채팅 기록 화면에 실제 데이터를 불러올 수 있도록 API 연동 및 바인딩을 추가한 작업입니다. 사용자 토큰을 이용해 기록 목록을 불러오고, 결과가 없을 경우 안내 문구를 보여 줍니다.

## 관련 이슈

없음

## 작업 내용

-   `getRecordListApi` 추가: 사용자 토큰 기반 채팅 기록 목록 조회 API 함수 구현
-   기존 `RecordDate`, `RecordDateDesk `컴포넌트에 API 연동 로직 추가
-   빈 목록일 경우 '기록된 내용이 없습니다' 안내 문구 표시
-   응답 데이터 구조에 따라 `res.records || res` 방식으로 처리하여 유연성 확보

## 공유사항

-   테스트를 위해선 토큰에 연결된 실제 기록 데이터가 존재해야 합니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
