### PR TITLE
[Refactor] 기록 목록 경로 수정 및 모바일 화면 최적화를 위한 하단바 높이·이미지 크기 조정

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -8,6 +8,8 @@ import HomeOff from '../../assets/HomeOff.svg';
 import HomeOn from '../../assets/HomeOn.svg';
 import InsightOff from '../../assets/InsightOff.svg';
 import InsightOn from '../../assets/InsightOn.svg';
+import ReportOff from '../../assets/ReportOff.svg';
+import ReportOn from '../../assets/ReportOn.svg';
 
 const Footer = () => {
     const location = useLocation();
@@ -15,7 +17,7 @@ const Footer = () => {
     const navigate = useNavigate();
 
     const goToRecord = () => {
-        navigate('/recordcategory');
+        navigate('/recorddate');
     };
 
     const goToHome = () => {
@@ -25,6 +27,10 @@ const Footer = () => {
     const goToInsight = () => {
         navigate('/insight');
     };
+
+    // const goToReport = () => {
+    //     navigate('/report');
+    // };
 
     return (
         <F.Container>

--- a/src/components/footer/FooterStyles.jsx
+++ b/src/components/footer/FooterStyles.jsx
@@ -4,7 +4,7 @@ export const Container = styled.div`
     position: fixed;
     bottom: 0;
     width: 393px;
-    height: 110px;
+    height: 100px;
     padding: 0;
     box-sizing: border-box;
     display: flex;
@@ -27,8 +27,8 @@ export const Record = styled.div`
 
 export const RecordImg = styled.div`
     img {
-        width: 50px;
-        height: 50px;
+        width: 45px;
+        height: 45px;
     }
 `;
 
@@ -48,8 +48,8 @@ export const Home = styled.div`
 
 export const HomeImg = styled.div`
     img {
-        width: 55px;
-        height: 55px;
+        width: 50px;
+        height: 50px;
     }
 `;
 
@@ -68,8 +68,8 @@ export const Insight = styled.div`
 
 export const InsightImg = styled.div`
     img {
-        width: 50px;
-        height: 50px;
+        width: 48px;
+        height: 48px;
     }
 `;
 


### PR DESCRIPTION
# [refactor/footer] 기록 목록 경로 수정 및 모바일 화면 최적화를 위한 하단바 높이·이미지 크기 조정

## PR요약

해당 pr은
-   기존에 구현되어 있던 기록 목록 버튼의 이동 경로를 `/recorddate`로 변경하고, 모바일 화면에서 UI 가독성을 높이기 위해 하단바의 높이 및 아이콘 이미지 크기를 조정한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   기록 목록 버튼의 이동 경로를 `/recordcategory`에서 `/recorddate`로 수정
    -   카테고리별 기록 목록 조회 기능이 제거되었기 때문에 해당 페이지(`/recordcategory`) 대신 `/recorddate`로 경로를 변경함
-   `FooterStyles.jsx`에서 하단바 높이와 각 버튼 아이콘 이미지 크기를 축소
    -   모바일 환경에서 UI가 너무 커 보이는 문제를 개선하기 위해 조정

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
