### PR TITLE
[Refactor] 기능 정리와 UX 개선을 위한 문구 수정 및 구조 리팩토링

### DIFF
--- a/src/components/header/SettingsHeader.jsx
+++ b/src/components/header/SettingsHeader.jsx
@@ -29,12 +29,18 @@ const SettingsHeader = () => {
         password: '',
     });
 
-    const titleText =
-        location.pathname === '/insight'
-            ? 'WIDER와 함께한 사고 연습,\n그동안의 레벨 변화는 어땠을까요?'
-            : location.pathname === '/insightchart'
-            ? 'WIDER와 함께한 이번 달 사고 연습,\n내 사고 레벨은 어디쯤일까요?'
-            : '리포트 기록을 확인해 보세요!';
+    // const titleText =
+    //     location.pathname === '/insight'
+    //         ? 'WIDER와 함께한 사고 연습,\n그동안의 레벨 변화는 어땠을까요?'
+    //         : location.pathname === '/insightchart'
+    //         ? 'WIDER와 함께한 이번 달 사고 연습,\n내 사고 레벨은 어디쯤일까요?'
+    //         : '리포트 기록을 확인해 보세요!';
+
+    const isHome = location.pathname === '/home';
+
+    const title = isHome ? '나의 AI 파트너, WIDER와' : '이전 대화를 다시 보고 싶다면?';
+
+    const subtitle = isHome ? '오늘의 대화를 시작해 보세요!' : '기록 목록에서 확인해 보세요!';
 
     const toggleDropdown = () => {
         setShowDropdown((prev) => !prev);
@@ -106,6 +112,24 @@ const SettingsHeader = () => {
         }
     };
 
+    // const confirmLogout = async () => {
+    //     try {
+    //         const sessionId = localStorage.getItem('latest_session_id');
+    //         const sessionDate = localStorage.getItem('latest_session_date');
+
+    //         localStorage.clear();
+
+    //         if (sessionId) localStorage.setItem('latest_session_id', sessionId);
+    //         if (sessionDate) localStorage.setItem('latest_session_date', sessionDate);
+
+    //         await dispatch(serverLogout(token));
+    //         dispatch(logout());
+    //         navigate('/');
+    //     } catch (e) {
+    //         alert('로그아웃 실패');
+    //     }
+    // };
+
     const cancelLogout = () => {
         setShowLogoutConfirm(false);
     };
@@ -145,7 +169,18 @@ const SettingsHeader = () => {
                         <Sh.Rectangle>
                             <img src={Rectangle} />
                         </Sh.Rectangle>
-                        <Sh.TitleText>{titleText}</Sh.TitleText>
+                        <Sh.HeaderText
+                            style={{
+                                position: 'relative',
+                                zIndex: 1,
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                            }}
+                        >
+                            <Sh.ServiceName>{title}</Sh.ServiceName>
+                            <Sh.ServiceTagline>{subtitle}</Sh.ServiceTagline>
+                        </Sh.HeaderText>
                     </Sh.Title>
                 </Sh.Left>
                 <Sh.Right>
@@ -161,7 +196,7 @@ const SettingsHeader = () => {
                         <span>아이디</span> <span style={{ color: '#aaa' }}>{user.id}</span>
                     </Sh.ItemRow>
                     <Sh.ItemRow onClick={handlePasswordChangeClick}>비밀번호 변경</Sh.ItemRow>
-                    <Sh.ItemRow>채팅 알림 기능</Sh.ItemRow>
+                    {/* <Sh.ItemRow>채팅 알림 기능</Sh.ItemRow> */}
                     <Sh.SectionTitle>서비스</Sh.SectionTitle>
                     <Sh.ItemRow onClick={goToTermsPage}>서비스 이용 약관</Sh.ItemRow>
                     <Sh.ItemRow onClick={handleLogoutClick}>로그아웃</Sh.ItemRow>
@@ -200,6 +235,23 @@ const SettingsHeader = () => {
                             onChange={handleInputChange}
                         />
                         <Sh.SubmitButton onClick={handleSubmitPasswordChange}>변경하기</Sh.SubmitButton>
+                        <Sh.SubmitButton
+                            onClick={() => {
+                                setShowPasswordBox(false);
+                                setShowDropdown(false);
+                            }}
+                        >
+                            취소
+                        </Sh.SubmitButton>
+                    </Sh.PasswordBox>
+                </Sh.PasswordOverlay>
+            )}
+            {showLogoutConfirm && (
+                <Sh.PasswordOverlay>
+                    <Sh.PasswordBox>
+                        <Sh.ConfirmText>정말 로그아웃하시겠습니까?</Sh.ConfirmText>
+                        <Sh.LogoutButton onClick={confirmLogout}>확인</Sh.LogoutButton>
+                        <Sh.LogoutButton onClick={cancelLogout}>취소</Sh.LogoutButton>
                     </Sh.PasswordBox>
                 </Sh.PasswordOverlay>
             )}

--- a/src/components/header/SettingsHeaderStyles.jsx
+++ b/src/components/header/SettingsHeaderStyles.jsx
@@ -29,22 +29,27 @@ export const Logo = styled.div`
         width: 65px;
         height: 65px;
     }
-    margin-left: 10%;
 `;
 
 export const Title = styled.div`
     position: relative;
+    min-width: 300px;
+    height: 50px;
+    margin-right: auto;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    min-width: 300px;
-    height: 40px;
+    gap: 5px;
+    color: #4e4e4e;
+    font-weight: bold;
+    font-size: 12px;
     flex-shrink: 0;
 `;
 
 export const Rectangle = styled.div`
     position: absolute;
-    left: 0;
+    left: 10px;
     top: 5;
     img {
         width: 210px;
@@ -58,11 +63,23 @@ export const TitleText = styled.div`
     color: #4e4e4e;
     font-weight: bold;
     white-space: nowrap;
-    margin-left: -90px;
     z-index: 1;
     white-space: pre-line;
 `;
 
+export const ServiceName = styled.div`
+    font-size: 12px;
+    color: #4e4e4e;
+`;
+
+export const ServiceTagline = styled.div`
+    font-size: 12px;
+    color: #4e4e4e;
+`;
+
+export const HeaderText = styled.div`
+    margin-left: -60px;
+`;
 export const Right = styled.div`
     flex: 1;
     display: flex;


### PR DESCRIPTION
# [feature/setting] 기능 정리와 UX 개선을 위한 문구 수정 및 구조 리팩토링

## PR요약

해당 pr은
-   설정 헤더 컴포넌트의 UI/UX를 개선하고 기능 정리를 반영하기 위해 문구 수정 및 모달 동작 개선, 주석 정리 등을 포함한 리팩토링 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   문구 및 UI 수정
    -   홈/기록 목록 페이지에서 문구 수정 (`title`, `subtitle`)
    -   인사이트 페이지 제거 가능성 고려해 기존 `titleText` 관련 로직 주석 처리
-   기능 개선 및 정리
    -   비밀번호 변경 모달에 '취소' 버튼 추가 → 클릭 시 모달 닫힘 처리
    -   채팅 알림 관련 기능 제거에 따른 UI 주석 처리
    -   로그아웃 시 `session_id` 유지 고려 → `localStorage` 저장/삭제 방식 주석 처리르 백업
-   구조 리팩토링
    -   불필요한 코드 주석 처리
    -   변수 및 함수 명확화 (`title`, `subtitle` 분리 등)

## 공유사항

-   기존 코드 구조를 최대한 유지하며 기능 정리 중심으로 개선했습니다.
-   `session_id` 관련 로직은 주석 처리해 백업 형태로 남겨두었습니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
