### PR TITLE
[Refactor] 카테고리별 기록 목록 기능 제거에 따라 기록 버튼 클릭 시 /recorddate로 이동하도록 수정

### DIFF
--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -27,7 +27,7 @@ const Sidebar = () => {
     };
 
     const goToRecord = () => {
-        navigate('/recordcategory');
+        navigate('/recorddate');
     };
 
     const goToInsight = () => {


### PR DESCRIPTION
# [fix/sidebar] 카테고리별 기록 목록 기능 제거에 따라 기록 버튼 클릭 시 /recorddate로 이동하도록 수정

## PR요약

해당 pr은
-   기존에 기록 목록 버튼 클릭 시 이동하던 `/recordcategory` 경로가 제거됨에 따라, 버튼 클릭 시 바로 날짜별 기록 목록을 조회하는 `/recorddate` 경로로 이동하도록 수정한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   Sidebar.jsx
    -   기존에 `recordcategory`로 이동하던 기록 버튼의 경로를 `/recorddate`로 변경
    -   카테고리 기반 기록 목록 기능이 제거되어, 기능 흐름에 맞춰 라우팅 수정

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
