### PR TITLE
[Refactor] 채팅 응답 구조 및 리포트 생성 데이터 개선

### DIFF
--- a/src/pages/chat/ChatDeskScreen.jsx
+++ b/src/pages/chat/ChatDeskScreen.jsx
@@ -22,20 +22,6 @@ const ChatDesk = () => {
     const sessionId = location.state?.sessionId || localStorage.getItem('latest_session_id');
     const textareaRef = useRef(null);
 
-    // useEffect(() => {
-    //     const fetchChatStart = async () => {
-    //         try {
-    //             const data = await startChatApi(token);
-    //             setChatData(data);
-    //             setChatLog([{ sender: 'bot', text: data.question }]);
-    //         } catch (error) {
-    //             console.error('채팅 시작 실패:', error);
-    //         }
-    //     };
-
-    //     fetchChatStart();
-    // }, [token]);
-
     const handleSendAnswer = async () => {
         if (!chatData || userAnswer.trim() === '') return;
         setIsSending(true);
@@ -43,47 +29,58 @@ const ChatDesk = () => {
         const payload = {
             session_id: chatData.session_id,
             topic: chatData.topic,
+            topic_prompt: chatData.topic_prompt || '',
             current_level: chatData.current_level,
             user_answer: userAnswer,
         };
 
+        console.log('respondChatApi로 보낼 payload:', payload);
+
         try {
-            // 사용자 답변 추가
             const userMsg = userAnswer;
             setUserAnswer('');
-            if (textareaRef.current) textareaRef.current.style.height = 'auto';
+            if (textareaRef.current) textareaRef.current.style.height = '40px';
 
             setChatLog((prev) => [...prev, { sender: 'user', text: userMsg }]);
 
             const response = await respondChatApi(token, payload);
 
-            // 다음 질문 추가
             setChatData(response);
+
+            if (response.message?.trim()) {
+                setChatLog((prev) => [...prev, { sender: 'bot', text: response.message }]);
+            }
+
             if (response.question?.trim()) {
                 setChatLog((prev) => [...prev, { sender: 'bot', text: response.question }]);
             }
 
             if (response.is_complete) {
                 setIsComplete(true);
-
                 const endPayload = {
                     session_id: response.session_id,
                     topic: response.topic,
                     current_level: response.current_level,
                     question: response.question,
                 };
-
                 const endResponse = await endChatApi(token, endPayload);
-                setSummary(endResponse);
+                setSummary(endResponse.summary);
                 setCompletionMessage(endResponse.message);
                 console.log('종료 응답:', endResponse);
 
+                // 리포트 생성 API 호출
                 try {
                     const reportPayload = {
-                        report_id: crypto.randomUUID(),
+                        report_id: crypto.randomUUID(), // UUID 자동 생성
                         session_id: chatData.session_id,
-                        report: endResponse,
+                        report: {
+                            ...endResponse,
+                            level: chatData.current_level,
+                        },
                     };
+
+                    console.log('리포트 생성 전 payload:', reportPayload);
+                    console.log('endChat 응답 전체:', endResponse);
 
                     const generatedReport = await generateReportApi(chatData.session_id, token, reportPayload);
                     console.log('리포트 생성 완료:', generatedReport);
@@ -92,59 +89,88 @@ const ChatDesk = () => {
                 }
             }
         } catch (err) {
-            console.error('응답 처리 실패:', err);
+            console.error('답변 실패:', err);
+            console.log('서버 응답 내용:', err.response?.data || '응답 없음');
         } finally {
             setIsSending(false);
         }
     };
 
     // useEffect(() => {
-    //     const fetchChatHistory = async () => {
-    //         const sessionId = location.state?.sessionId; // report에서 온 경우
-    //         console.log('받은 sessionId:', sessionId);
-    //         if (!sessionId) return;
-
+    //     const initChat = async () => {
     //         try {
-    //             const data = await getChatHistoryApi(sessionId, token);
-    //             const formattedChat = data.messages.map((msg) => ({
-    //                 sender: msg.speaker === 'AI' ? 'bot' : 'user',
-    //                 text: msg.content,
-    //             }));
-    //             setChatLog(formattedChat);
-    //             setChatData({ session_id: data.session_id }); // 최소한으로 필요한 필드
-    //             setIsComplete(true); // 기록은 완료된 세션이므로 입력창 숨기기
+    //             if (sessionId) {
+    //                 console.log('기존 세션 불러오기:', sessionId);
+    //                 const data = await getChatHistoryApi(sessionId, token);
+    //                 console.log('getChatHistoryApi 응답:', data);
+
+    //                 // 세션이 유효하지 않거나 기록이 없으면 새로운 채팅 시작
+    //                 if (!data.messages || data.messages.length === 0) {
+    //                     console.log('기록 없으므로 새로운 채팅 시작');
+    //                     localStorage.removeItem('latest_session_id');
+    //                     throw new Error('기록 없음'); // 아래 새 시작 로직으로 이동
+    //                 }
+
+    //                 if (!data.topic || !data.current_level) {
+    //                     console.warn('topic이나 current_level 없으므로 새 startChat 호출');
+    //                     localStorage.removeItem('latest_session_id');
+
+    //                     const newData = await startChatApi(token);
+    //                     setChatData(newData);
+    //                     setChatLog([{ sender: 'bot', text: newData.question }]);
+    //                     localStorage.setItem('latest_session_id', newData.session_id);
+    //                     return;
+    //                 }
+
+    //                 const formattedChat = data.messages.map((msg) => ({
+    //                     sender: msg.speaker === 'AI' ? 'bot' : 'user',
+    //                     text: msg.content,
+    //                 }));
+
+    //                 setChatLog(formattedChat);
+    //                 setChatData({
+    //                     session_id: data.session_id,
+    //                     topic: data.topic,
+    //                     current_level: data.current_level,
+    //                 });
+    //                 setIsComplete(data.is_complete); // 서버에서 complete 알려준 경우
+    //                 return;
+    //             }
+
+    //             throw new Error('sessionId 없음');
     //         } catch (err) {
-    //             console.error('채팅 기록 불러오기 실패:', err);
+    //             console.log('새 세션 시작');
+    //             try {
+    //                 const data = await startChatApi(token);
+    //                 setChatData(data);
+    //                 console.log('startChat 응답:', data);
+    //                 setChatLog([{ sender: 'bot', text: data.question }]);
+    //                 localStorage.setItem('latest_session_id', data.session_id);
+    //             } catch (startErr) {
+    //                 console.error('새로운 채팅 시작 실패:', startErr);
+    //             }
     //         }
     //     };
 
-    //     fetchChatHistory();
-    // }, [token]);
+    //     initChat();
+    // }, [sessionId, token]);
 
     useEffect(() => {
         const initChat = async () => {
+            const savedDate = localStorage.getItem('latest_session_date');
+            const today = new Date().toISOString().split('T')[0];
+
+            // 날짜가 다르면 새로운 세션 시작
+            const shouldStartNewChat = savedDate !== today;
+
             try {
-                if (sessionId) {
-                    console.log('기존 세션 불러오기:', sessionId);
+                if (!shouldStartNewChat && sessionId) {
                     const data = await getChatHistoryApi(sessionId, token);
-                    console.log('getChatHistoryApi 응답:', data);
 
-                    // 세션이 유효하지 않거나 기록이 없으면 새로운 채팅 시작
                     if (!data.messages || data.messages.length === 0) {
-                        console.log('기록 없으므로 새로운 채팅 시작');
                         localStorage.removeItem('latest_session_id');
-                        throw new Error('기록 없음'); // 아래 새 시작 로직으로 이동
-                    }
-
-                    if (!data.topic || !data.current_level) {
-                        console.warn('topic이나 current_level 없으므로 새 startChat 호출');
-                        localStorage.removeItem('latest_session_id');
-
-                        const newData = await startChatApi(token);
-                        setChatData(newData);
-                        setChatLog([{ sender: 'bot', text: newData.question }]);
-                        localStorage.setItem('latest_session_id', newData.session_id);
-                        return;
+                        localStorage.removeItem('latest_session_date');
+                        throw new Error('기록 없음');
                     }
 
                     const formattedChat = data.messages.map((msg) => ({
@@ -158,22 +184,18 @@ const ChatDesk = () => {
                         topic: data.topic,
                         current_level: data.current_level,
                     });
-                    setIsComplete(data.is_complete); // 서버에서 complete 알려준 경우
+                    setIsComplete(data.is_complete);
                     return;
                 }
 
-                throw new Error('sessionId 없음');
+                // 새로운 채팅 시작
+                const newData = await startChatApi(token);
+                setChatData(newData);
+                setChatLog([{ sender: 'bot', text: newData.question }]);
+                localStorage.setItem('latest_session_id', newData.session_id);
+                localStorage.setItem('latest_session_date', today);
             } catch (err) {
-                console.log('새 세션 시작');
-                try {
-                    const data = await startChatApi(token);
-                    setChatData(data);
-                    console.log('startChat 응답:', data);
-                    setChatLog([{ sender: 'bot', text: data.question }]);
-                    localStorage.setItem('latest_session_id', data.session_id);
-                } catch (startErr) {
-                    console.error('새로운 채팅 시작 실패:', startErr);
-                }
+                console.error('채팅 초기화 실패:', err);
             }
         };
 

--- a/src/pages/chat/ChatScreenStyles.jsx
+++ b/src/pages/chat/ChatScreenStyles.jsx
@@ -47,21 +47,6 @@ export const LogoIcon = styled.div`
 `;
 
 export const HeaderText = styled.div`
-    /* margin-right: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-    margin-left: -25px;
-    position: relative;
-    width: 180px;
-    height: 50px;
-    align-items: center;
-    justify-content: center;
-    color: #4e4e4e;
-    font-weight: bold;
-    font-size: 12px;
-    padding: 10px 10px;
-    font-size: 12px; */
     position: relative;
     width: 180px;
     height: 50px;


### PR DESCRIPTION
# [feature/chat] 채팅 응답 구조 및 리포트 생성 데이터 개선

## PR요약

해당 pr은
-   채팅 응답 구조와 리포트 생성 데이터를 개선하여 기능을 정비하고 필요한 정보를 추가한 작업입니다.
-   채팅 응답 시 필요한 추가 정보를 포함시키고, 리포트 생성 시 사용자 레벨 정보를 함께 저장하도록 개선했습니다.

## 관련 이슈

없음

## 작업 내용

-   `ChatDeskScreen.jsx`, `ChatScreen.jsx`
    -   채팅 응답 데이터에 `topic_prompt` 포함되도록 수정
    -   기존에는 `question`만 응답됐던 구조를 `message`까지 포함해 리팩토링하여 기록 용이성 향상
-   `ChatScreenStyles.jsx`
    -   사용되지 않는 주석 및 스타일 제거로 코드 정리
-   리포트 생성 시 서버로 `level` 값 함께 전송되도록 데이터 구조 확장

## 공유사항

-   백엔드에서 응답 형식이 바뀌었거나 바뀔 가능성이 있다면 프론트 구조와 동기화 여부 확인 필요
-   `topic_prompt`와 `message`는 모두 리포트 생성 시 활용되므로 누락되지 않도록 확인 필요

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
