### PR TITLE
[Refactor] 홈 화면 설정 헤더 적용 및 문구 수정

### DIFF
--- a/src/pages/home/HomeDeskScreen.jsx
+++ b/src/pages/home/HomeDeskScreen.jsx
@@ -21,7 +21,12 @@ const HomeDesk = () => {
     };
 
     const goToReport = () => {
-        navigate('/report');
+        const sessionId = localStorage.getItem('latest_session_id');
+        navigate('/report', {
+            state: {
+                sessionId,
+            },
+        });
     };
 
     useEffect(() => {
@@ -45,7 +50,7 @@ const HomeDesk = () => {
                 <Hd.Title>오늘의 질문</Hd.Title>
                 <Hd.Question onClick={goToChat}>{todayTopic}</Hd.Question>
                 <Hd.StartConversation>터치하여 대화를 시작하세요!</Hd.StartConversation>
-                <Hd.ReportCreated>어제의 리포트가 생성되었습니다!</Hd.ReportCreated>
+                <Hd.ReportCreated>오늘의 리포트가 생성되었습니다!</Hd.ReportCreated>
                 <Hd.ButtonReport onClick={goToReport}>리포트 보러 가기</Hd.ButtonReport>
             </Hd.Content>
             <Sidebar />

--- a/src/pages/home/HomeScreen.jsx
+++ b/src/pages/home/HomeScreen.jsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { getTodayTopicApi } from '../../api/home/getTopicApi';
+import { getReportBySessionIdApi } from '../../api/report/ReportApi';
 import * as H from './HomeScreenStyles.jsx';
 import LogoIcon from '../../assets/LogoIcon.png';
-import BellOff from '../../assets/BellOff.png';
+// import BellOff from '../../assets/BellOff.png';
 // import BellOn from '../../assets/BellOn.png';
+import Header from '../../components/header/SettingsHeader.jsx';
 import Footer from '../../components/footer/Footer.jsx';
 import RectangleHeader from '../../assets/RectangleHeader.svg';
 
@@ -24,7 +26,12 @@ const Home = () => {
     };
 
     const goToReport = () => {
-        navigate('/report');
+        const sessionId = localStorage.getItem('latest_session_id');
+        navigate('/report', {
+            state: {
+                sessionId,
+            },
+        });
     };
 
     const goToNotification = () => {
@@ -47,7 +54,7 @@ const Home = () => {
 
     return (
         <H.Container>
-            <H.Header>
+            {/* <H.Header>
                 <H.LogoIcon>
                     <img src={LogoIcon} />
                 </H.LogoIcon>
@@ -69,7 +76,8 @@ const Home = () => {
                 <H.BellOff onClick={goToNotification}>
                     <img src={BellOff} />
                 </H.BellOff>
-            </H.Header>
+            </H.Header> */}
+            <Header />
             <H.Content>
                 <H.Title>오늘의 질문</H.Title>
                 <H.Question onClick={goToChat}>{todayTopic}</H.Question>
@@ -77,7 +85,7 @@ const Home = () => {
                     터치하여 대화를 <br />
                     시작하세요!
                 </H.StartConversation>
-                <H.ReportCreated>어제의 리포트가 생성되었습니다!</H.ReportCreated>
+                <H.ReportCreated>오늘의 리포트가 생성되었습니다!</H.ReportCreated>
                 <H.ButtonReport onClick={goToReport}>리포트 보러 가기</H.ButtonReport>
             </H.Content>
             <Footer />

--- a/src/pages/home/HomeScreenStyles.jsx
+++ b/src/pages/home/HomeScreenStyles.jsx
@@ -105,7 +105,7 @@ export const Title = styled.div`
 export const Question = styled.div`
     background-color: #e6f7ff;
     width: 300px;
-    height: 130px;
+    height: 110px;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
# [feature/home] 홈 화면 설정 헤더 적용 및 문구 수정

## PR요약

해당 pr은
-   인사이트 기능 제거에 따라 홈 화면에 설정 헤더를 적용했습니다.
-   전날 리포트 조회 기능이 제거됨에 따라 문구를 '오늘의 리포트 조회'로 수정했습니다.
-   오늘 생성된 리포트 페이지로 이동하는 기능을 추가한 작업입니다.

## 관련 이슈

해당 작업은 별도 이슈 없이 진행되었습니다.

## 작업 내용

-   HomeDeskScreen.jsx, HomeScreen.jsx
    -   인사이트 페이지 제거에 따라 홈 화면에 `SettingsHeader` 컴포넌트 적용
    -   리포트 관련 문구를 '오늘의 리포트'로 수정
    -   최근 세션 ID(localStorage) 기반으로 리포트 페이지(`/report`)로 이동하는 기능 추가

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
