### PR TITLE
[Feat] 리포트 레벨 및 피드백 문구 추가, 모바일·데스크 UI 통일

### DIFF
--- a/src/pages/report/ReportDeskScreen.jsx
+++ b/src/pages/report/ReportDeskScreen.jsx
@@ -13,6 +13,14 @@ const ReportDesk = () => {
     const token = useSelector((state) => state.user.token);
     const sessionId = location.state?.sessionId;
     const [report, setReport] = useState(null);
+    const bloomLevelDescriptions = {
+        1: 'Remember: 사실을 기억하고 열거',
+        2: 'Understand: 의미를 파악하고 해석',
+        3: 'Apply: 개념을 적용하고 실행',
+        4: 'Analyze: 구조를 분석하고 비교',
+        5: 'Evaluate: 판단하고 비판적으로 평가',
+        6: 'Create: 새로운 아이디어를 종합하고 창출',
+    };
 
     useEffect(() => {
         const fetchReport = async () => {
@@ -38,82 +46,12 @@ const ReportDesk = () => {
                 <Rd.ArrowLeft onClick={() => navigate(-1)}>
                     <img src={ArrowLeft} />
                 </Rd.ArrowLeft>
-                {/* <Rd.HeaderText>2025 / 03 / 25 Report</Rd.HeaderText> */}
                 <Rd.HeaderText>{new Date().toISOString().split('T')[0]} Report</Rd.HeaderText>
             </Rd.Header>
-            {/* <Rd.Content>
-                <Rd.Level>Level 2</Rd.Level>
-                <Rd.Feedback>
-                    <Rd.FeedbackTitle>Understand: 의미를 파악하고 해석</Rd.FeedbackTitle>
-                </Rd.Feedback>
-                <Rd.Grid>
-                    <Rd.LeftColumn>
-                        <Rd.Summary>
-                            <Rd.SummaryTitle>이번 대화를 짧게 요약해드릴게요!</Rd.SummaryTitle>
-                            <Rd.SummaryContent>
-                                나는 대선 후보 단일화에 대해 정책 상호작용, 정치적 영향 등을 분석하며 다양한 전략을
-                                고민했어요. 유권자의 인식 변화와 정책 조율 문제를 함께 다뤘고, 이론적인 통찰을 바탕으로
-                                실천 방안도 제안했어요.
-                            </Rd.SummaryContent>
-                        </Rd.Summary>
-                        <Rd.Suggestion>
-                            <Rd.SuggestionTitle>이런 점이 좋았어요!</Rd.SuggestionTitle>
-                            <Rd.SuggestionSubTitle>정교한 분석 능력</Rd.SuggestionSubTitle>
-                            <Rd.SuggestionContent>
-                                정책의 상호작용과 유권자에게 미치는 영향을 잘 분석했습니다. 특히, 정책의 보완성 또는
-                                충돌 가능성을 언급하며 유권자 인식에 대한 통찰을 보여주었습니다.
-                            </Rd.SuggestionContent>
-                            <Rd.SuggestionContent>
-                                대선 후보 단일화 과정에서는 각 후보의 정책이 상호 보완적이거나 충돌할 수 있습니다.
-                            </Rd.SuggestionContent>
-                        </Rd.Suggestion>
-                    </Rd.LeftColumn>
-                    <Rd.LineVertical>
-                        <img src={LineVertical} />
-                    </Rd.LineVertical>
-                    <Rd.RightColumn>
-                        <Rd.Suggestion>
-                            <Rd.SuggestionTitle>이렇게 해 보는 거 어때요?</Rd.SuggestionTitle>
-                            <Rd.SuggestionSubTitle>실제 사례의 부족</Rd.SuggestionSubTitle>
-                            <Rd.SuggestionContent>
-                                이론적인 분석은 뛰어나지만, 구체적인 사례나 데이터를 통한 실질적인 뒷받침이 부족합니다.
-                                이를 통해 주장의 신뢰성을 높일 수 있습니다.
-                            </Rd.SuggestionContent>
-                            <Rd.SuggestionContent>
-                                대선 후보 단일화의 실제 사례를 조사하고, 관련 데이터를 수집하여 분석에 포함시켜 보세요.
-                            </Rd.SuggestionContent>
-                            <Rd.SuggestionSubTitle>사례 연구</Rd.SuggestionSubTitle>
-                            <Rd.SuggestionContent>
-                                실제 대선 후보 단일화 사례를 분석하여 그 결과를 비교 분석하는 연습을 해보세요. 이를 통해
-                                이론을 실제에 적용하는 능력을 키울 수 있습니다.
-                            </Rd.SuggestionContent>
-                            <Rd.SuggestionContent>
-                                과거의 대선 후보 단일화 사례에서 어떤 성공과 실패가 있었나요?
-                            </Rd.SuggestionContent>
-                            <Rd.SuggestionContent>
-                                이러한 사례들이 현재의 분석에 어떤 영향을 미칠 수 있을까요?
-                            </Rd.SuggestionContent>
-                            <Rd.SuggestionContent>
-                                실제 데이터를 통해 내 주장을 어떻게 강화할 수 있을까요?
-                            </Rd.SuggestionContent>
-                        </Rd.Suggestion>
-                        <Rd.Example>
-                            <Rd.ExampleContent>
-                                "대선 후보 단일화 과정에서 협상과 합의의 중요성을 배웠습니다. 향후 선거에서는 후보 간
-                                정책 조율 메커니즘을 통해 단일화 이후의 정책 일관성을 확보하며, 유권자 지지 기반 분석을
-                                통해 표 이동을 최소화하는 전략이 필요합니다. 또한, 과거 사례를 분석하여 민주적 다양성을
-                                유지하는 방안을 모색하겠습니다."
-                            </Rd.ExampleContent>
-                        </Rd.Example>
-                    </Rd.RightColumn>
-                </Rd.Grid>
-            </Rd.Content> */}
             {report ? (
                 <Rd.Content>
-                    <Rd.Level>{report.level || 'Level ?'}</Rd.Level>
-                    <Rd.Feedback>
-                        <Rd.FeedbackTitle>{report.feedback_type || '피드백 유형 없음'}</Rd.FeedbackTitle>
-                    </Rd.Feedback>
+                    <Rd.Level> Level {report.raw_data.bloom_level}</Rd.Level>
+                    <Rd.LevelDescription>{bloomLevelDescriptions[report.raw_data.bloom_level]}</Rd.LevelDescription>
 
                     <Rd.Grid>
                         <Rd.LeftColumn>

--- a/src/pages/report/ReportDeskScreenStyles.jsx
+++ b/src/pages/report/ReportDeskScreenStyles.jsx
@@ -56,6 +56,14 @@ export const Level = styled.div`
     margin-left: 100px;
 `;
 
+export const LevelDescription = styled.div`
+    font-size: 18px;
+    font-weight: bold;
+    color: #333;
+    margin-top: 15px;
+    margin-left: 100px;
+`;
+
 export const Feedback = styled.div`
     color: #383636;
     margin-top: 1%;
@@ -129,19 +137,19 @@ export const Example = styled.div`
 `;
 
 export const ExampleContent = styled.div`
-    font-size: 13px;
+    font-size: 12.5px;
     font-weight: bold;
     color: #383636;
     background-color: #dff1ff;
     border-radius: 20px;
     margin-top: 5%;
-    width: 110%;
+    width: 95%;
     min-height: 80px;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 16px 12px;
+    padding: 20px 20px;
 `;
 
 export const Grid = styled.div`

--- a/src/pages/report/ReportScreen.jsx
+++ b/src/pages/report/ReportScreen.jsx
@@ -11,6 +11,14 @@ const Report = () => {
     const location = useLocation();
     const token = useSelector((state) => state.user.token);
     const [report, setReport] = useState(null);
+    const bloomLevelDescriptions = {
+        1: 'Remember: 사실을 기억하고 열거',
+        2: 'Understand: 의미를 파악하고 해석',
+        3: 'Apply: 개념을 적용하고 실행',
+        4: 'Analyze: 구조를 분석하고 비교',
+        5: 'Evaluate: 판단하고 비판적으로 평가',
+        6: 'Create: 새로운 아이디어를 종합하고 창출',
+    };
 
     const sessionId = location.state?.sessionId; // Chat에서 전달한 sessionId
 
@@ -18,6 +26,7 @@ const Report = () => {
         const fetchReport = async () => {
             try {
                 const res = await getReportBySessionIdApi(sessionId, token);
+                console.log('리포트 전체 데이터:', res);
                 setReport(res);
             } catch (err) {
                 console.error('리포트 불러오기 실패:', err);
@@ -39,21 +48,13 @@ const Report = () => {
             </R.Header>
             {report ? (
                 <R.Content>
-                    <R.Level>Level 2</R.Level>
+                    <R.Level>Level {report.raw_data.bloom_level}</R.Level>
+                    <R.LevelDescription>{bloomLevelDescriptions[report.raw_data.bloom_level]}</R.LevelDescription>
 
                     <R.Feedback>
-                        <R.FeedbackTitle>📝 요약</R.FeedbackTitle>
+                        <R.FeedbackTitle>이번 대화를 짧게 요약해드릴게요!</R.FeedbackTitle>
                         <R.FeedbackContent>{report.raw_data.summary}</R.FeedbackContent>
                     </R.Feedback>
-
-                    <R.Line>
-                        <img src={Line} />
-                    </R.Line>
-
-                    <R.Summary>
-                        <R.SummaryTitle>이번 대화를 짧게 요약해드릴게요!</R.SummaryTitle>
-                        <R.SummaryContent>{report.formatted_report}</R.SummaryContent>
-                    </R.Summary>
 
                     <R.Line>
                         <img src={Line} />

--- a/src/pages/report/ReportScreenStyles.jsx
+++ b/src/pages/report/ReportScreenStyles.jsx
@@ -11,8 +11,8 @@ export const Container = styled.div`
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
+    align-items: flex-start;
+    justify-content: flex-start;
     background-color: #ffffff;
 `;
 
@@ -32,7 +32,7 @@ export const Header = styled.div`
 
 export const ArrowLeft = styled.div`
     position: absolute;
-    left: 40px;
+    left: 10px;
     top: 15px;
     img {
         width: 30px;
@@ -53,7 +53,7 @@ export const Content = styled.div`
     padding: 0 40px 100px 40px;
     overflow-y: auto;
     height: calc(100vh - 60px);
-    width: 100%;
+    width: 80%;
     padding: 0 50px;
     display: flex;
     flex-direction: column;
@@ -64,6 +64,13 @@ export const Level = styled.div`
     font-size: 33px;
     color: #6ba9ec;
     font-weight: bold;
+`;
+
+export const LevelDescription = styled.div`
+    font-size: 18px;
+    font-weight: bold;
+    color: #333;
+    margin-top: 15px;
 `;
 
 export const Feedback = styled.div`
@@ -127,17 +134,18 @@ export const Example = styled.div`
 `;
 
 export const ExampleContent = styled.div`
-    font-size: 13px;
+    font-size: 12px;
     font-weight: bold;
     color: #383636;
     background-color: #dff1ff;
     border-radius: 20px;
     margin-top: 5%;
-    width: 100%;
-    height: 80%;
+    margin-bottom: 10%;
+    width: 80%;
+    height: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 10%;
+    padding: 7%;
 `;


### PR DESCRIPTION
# [feature/report] 리포트 레벨 및 피드백 문구 추가, 모바일·데스크 UI 통일

## PR요약

해당 pr은
-   리포트에 사용자 도달 레벨 정보를 시각화하고, 이에 맞는 블룸 레벨 설명 문구를 추가하여 리포트의 명확성과 활용도를 높이기 위한 작업입니다.
-   모바일과 데스크탑 리포트 화면의 UI를 통일하여 유지보수성과 일관성을 개선했습니다.

## 관련 이슈

없음

## 작업 내용

-   리포트 조회 API 결과에서 `bloom_level` 값을 활용해 레벨 시각화 및 피드백 문구 출력
-   `ReportScreen.jsx`, `ReportDeskScreen.jsx`에 블룸 레벨 설명 문구 매핑 추가
-   strengths, weaknesses, suggestions 항목 반복 렌더링 구조 통일
-   모바일과 데스크탑 리포트 UI 구조 동일하게 리팩토링
-   더 이상 사용하지 않는 주석 제거

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
