### PR TITLE
[Feat] 기록 목록에서 클릭 시 /chat 이동 및 대화 기록 불러오기 구현

### DIFF
--- a/src/api/chatRecord/RecordApi.js
+++ b/src/api/chatRecord/RecordApi.js
@@ -8,3 +8,12 @@ export const getRecordListApi = async (token) => {
     });
     return response.data;
 };
+
+export const getChatHistoryApi = async (sessionId, token) => {
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/api/records/${sessionId}`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return response.data;
+};

--- a/src/pages/chatRecord/RecordDate.jsx
+++ b/src/pages/chatRecord/RecordDate.jsx
@@ -54,7 +54,7 @@ const RecordDate = () => {
                     recordList.map((record) => (
                         <Rd.CategoryContent
                             key={record.session_id}
-                            onClick={() => navigate(`/report`, { state: { sessionId: record.session_id } })}
+                            onClick={() => navigate(`/chat`, { state: { sessionId: record.session_id } })}
                         >
                             <Rd.CategoryDate>{formatDate(record.started_at)}</Rd.CategoryDate>
                             <Rd.ContentTitle>{record.topic}</Rd.ContentTitle>

--- a/src/pages/chatRecord/RecordDateDesk.jsx
+++ b/src/pages/chatRecord/RecordDateDesk.jsx
@@ -41,7 +41,7 @@ const RecordDateDesk = () => {
                     recordList.map((record) => (
                         <R.CategoryContent
                             key={record.session_id}
-                            onClick={() => navigate(`/report`, { state: { sessionId: record.session_id } })}
+                            onClick={() => navigate(`/chat`, { state: { sessionId: record.session_id } })}
                         >
                             <R.CategoryDate>{formatDate(record.started_at)}</R.CategoryDate>
                             <R.ContentTitle>{record.topic}</R.ContentTitle>

--- a/src/pages/chatRecord/RecordDateStyles.jsx
+++ b/src/pages/chatRecord/RecordDateStyles.jsx
@@ -32,14 +32,14 @@ export const CategoryContent = styled.div`
     align-items: center;
     background-color: #e6e4e4;
     border-radius: 20px;
-    padding: 20px 45px;
+    padding: 20px 30px;
     color: #383636;
     font-weight: bold;
 `;
 
 export const CategoryDate = styled.div`
     font-size: 16px;
-    margin-right: 10px;
+    margin-right: 15px;
     white-space: nowrap;
 `;
 


### PR DESCRIPTION
# [feature/record] 기록 목록에서 클릭 시 /chat 이동 및 대화 기록 불러오기 구현

## PR요약

해당 pr은
-   기록 목록에서 특정 항목을 클릭하면 `/chat` 페이지로 이동하고, 해당 sessionId 기반으로 대화 기록을 불러오는 기능을 구현한 것입니다.

## 관련 이슈

없음

## 작업 내용

-   `getChatHistoryApi` 함수 추가 (`RecordApi.js`)
    -   특정 sessionId에 해당하는 채팅 기록 조회 API 연동
-   `RecordDate.jsx`, `RecordDateDesk.jsx` 수정
    -   기록 목록에서 항목 클릭 시 `/report` → `/chat` 경로로 변경
    -   `navigate` 시 `sessionId`를 함께 전달
-   `RecordDateStyles.jsx` 일부 스타일 수정

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
