### PR TITLE
[Feat] 히스토그램 API 연동 및 인사이트 화면 전체 개선 (/insight, /insightchart 등)

### DIFF
--- a/src/api/insight/InsightApi.js
+++ b/src/api/insight/InsightApi.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export const getLevelProgressApi = async (token) => {
+    const response = await axios.get(`${process.env.REACT_APP_API_URL}/api/level-progress`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    });
+    return response.data;
+};

--- a/src/pages/insight/Insight.jsx
+++ b/src/pages/insight/Insight.jsx
@@ -1,36 +1,63 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getLevelProgressApi } from '../../api/insight/InsightApi';
 import * as I from './InsightStyles.jsx';
 import Header from '../../components/header/SettingsHeader.jsx';
 import Footer from '../../components/footer/Footer.jsx';
 
-const dummyData = [
-    { month: '2025/01', levels: [50, 80, 60, 40, 30, 20] },
-    { month: '2025/02', levels: [50, 80, 60, 40, 30, 20] },
-    { month: '2025/03', levels: [50, 80, 60, 40, 30, 20] },
-    { month: '2025/04', levels: [50, 80, 60, 40, 30, 20] },
-    { month: '2025/05', levels: [50, 80, 60, 40, 30, 20] },
-    { month: '2025/06', levels: [50, 80, 60, 40, 30, 20] },
-];
-
 const InsightChart = () => {
     const navigate = useNavigate();
-
-    const goToInsightChart = () => {
-        navigate('/insightchart');
-    };
+    const token = useSelector((state) => state.user.token);
 
     const [term, setTerm] = useState('상반기');
     const [showDropdown, setShowDropdown] = useState(false);
+    const [chartData, setChartData] = useState([]);
 
     const toggleDropdown = () => setShowDropdown(!showDropdown);
     const selectTerm = (t) => {
         setTerm(t);
         setShowDropdown(false);
-        // 이후 서버에서 데이터 가져와야 함
     };
 
     const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const res = await getLevelProgressApi(token);
+
+                // 월별 L1~L6 빈도 계산
+                const monthly = {};
+
+                res.forEach(({ startedAt, maxBloomLevel }) => {
+                    const date = new Date(startedAt);
+                    const yyyy = date.getFullYear();
+                    const mm = String(date.getMonth() + 1).padStart(2, '0');
+                    const key = `${yyyy}/${mm}`;
+
+                    if (!monthly[key]) monthly[key] = [0, 0, 0, 0, 0, 0]; // L1~L6
+
+                    if (maxBloomLevel >= 1 && maxBloomLevel <= 6) {
+                        monthly[key][maxBloomLevel - 1]++;
+                    }
+                });
+
+                const filtered = Object.entries(monthly)
+                    .filter(([month]) => {
+                        const m = parseInt(month.split('/')[1]);
+                        return term === '상반기' ? m <= 6 : m >= 7;
+                    })
+                    .map(([month, levels]) => ({ month, levels }));
+
+                setChartData(filtered.sort((a, b) => a.month.localeCompare(b.month)));
+            } catch (err) {
+                console.error('레벨 진행 데이터 불러오기 실패:', err);
+            }
+        };
+
+        fetchData();
+    }, [term, token]);
 
     return (
         <I.Container>
@@ -45,13 +72,23 @@ const InsightChart = () => {
                         </I.Dropdown>
                     )}
                 </I.TermSelector>
-                <I.ChartGrid onClick={goToInsightChart}>
-                    {dummyData.map((data, index) => (
-                        <I.ChartBox key={index}>
+                <I.ChartGrid>
+                    {chartData.map((data, index) => (
+                        <I.ChartBox
+                            key={index}
+                            onClick={() =>
+                                navigate('/insightchart', {
+                                    state: {
+                                        chartData,
+                                        selectedMonth: data.month,
+                                    },
+                                })
+                            }
+                        >
                             <I.MonthText>{data.month}</I.MonthText>
                             <I.ChartBarGroup>
                                 {data.levels.map((value, i) => (
-                                    <I.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
+                                    <I.ChartBar key={i} height={`${value * 50}px`} color={levelColors[i]} />
                                 ))}
                             </I.ChartBarGroup>
                             <I.ChartLabelGroup>

--- a/src/pages/insight/InsightChart.jsx
+++ b/src/pages/insight/InsightChart.jsx
@@ -1,33 +1,63 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import * as Ic from './InsightChartStyles.jsx';
 import Header from '../../components/header/SettingsHeader.jsx';
 import Footer from '../../components/footer/Footer.jsx';
 
 const InsightChart = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const chartData = location.state?.chartData || [];
+    const selectedMonthFromNav = location.state?.selectedMonth;
 
     const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
-    const dummyData = {
-        month: '2025/01',
-        levels: [120, 180, 100, 80, 60, 40],
-        comment:
-            'B6님은 1월에 다양한 개념을 잘 이해하고 의미를 정확히 짚어냈어요.\n사고의 깊이가 점점 더해지고 있어요!',
-    };
 
-    const [selectedMonth, setSelectedMonth] = useState('2025/01');
+    const availableMonths = chartData.map((d) => d.month);
+    const [selectedMonth, setSelectedMonth] = useState(selectedMonthFromNav || availableMonths[0] || '');
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-    const months = ['2025/01', '2025/02', '2025/03', '2025/04', '2025/05', '2025/06'];
+    const selectedData = chartData.find((d) => d.month === selectedMonth);
+
+    const getMostFrequentLevel = (levels) => {
+        let maxCount = Math.max(...levels);
+        return levels.findIndex((v) => v === maxCount) + 1;
+    };
+
+    const levelComments = {
+        1: `이 달에는 학습한 개념들을 잘 기억하고, 주요 용어나 정의를 빠짐없이 떠올릴 수 있었습니다. 
+      이는 탄탄한 기초 이해를 위한 중요한 첫걸음이며, 꾸준한 복습과 반복 학습을 통해 더 깊은 사고로 확장될 수 있는 기반이 마련되었습니다.`,
+
+        2: `단순히 정보를 기억하는 데서 나아가, 그 의미와 맥락을 잘 파악하고 있었습니다. 
+      개념 간의 관계를 이해하고 설명할 수 있는 능력이 향상되었으며, 이는 사고의 뼈대를 세우는 중요한 단계입니다. 
+      앞으로 다양한 사례에 대한 해석과 설명을 시도해보면 더 좋은 성장을 기대할 수 있습니다.`,
+
+        3: `이 달에는 배운 개념을 실제 상황에 적용해보는 시도가 돋보였습니다. 
+      단순한 이해에 그치지 않고, 다양한 문제 상황에 맞게 지식을 유연하게 활용하는 모습이 인상적이었습니다. 
+      이러한 응용력은 사고의 실천적 전환점을 의미하며, 더 복잡한 문제에도 자신감을 가지고 접근할 수 있도록 이끕니다.`,
+
+        4: `개념이나 현상을 세분화하여 비교하거나 분류하고, 핵심 구조를 파악하려는 분석적 사고가 잘 드러났습니다. 
+      이 단계는 단순한 적용을 넘어서, 왜 그렇게 작동하는지를 이해하고 설명하려는 노력의 결과입니다. 
+      앞으로는 논리적 근거에 기반한 설명을 더 강화하면 심화된 분석 능력을 키울 수 있습니다.`,
+
+        5: `이 달에는 다양한 관점을 고려하여 평가하거나 판단하는 사고 수준에 도달했습니다. 
+      타당한 근거를 바탕으로 비교하고 결론을 내리는 과정에서 비판적 사고 역량이 향상되었고, 스스로의 사고를 성찰하는 능력 또한 강화되었습니다. 
+      더 넓은 시야에서 문제를 바라보는 연습을 지속하면 더욱 성숙한 사고가 가능할 것입니다.`,
+
+        6: `창의적인 아이디어를 제시하고, 기존의 개념들을 재구성하거나 새로운 방식으로 표현하려는 시도가 돋보였습니다. 
+      이는 블룸의 최상위 사고 수준에 해당하는 ‘창출’ 단계로, 스스로의 사고를 독립적이고 창의적으로 발전시킬 수 있다는 강력한 증거입니다. 
+      앞으로도 자유롭고 유연한 사고를 통해 새로운 관점과 해결책을 꾸준히 시도해 보세요.`,
+    };
+
+    const generatedComment = selectedData ? levelComments[getMostFrequentLevel(selectedData.levels)] : '';
 
     return (
         <Ic.Container>
             <Header />
             <Ic.Content>
-                <Ic.MonthTitle onClick={() => setIsDropdownOpen(!isDropdownOpen)}>{selectedMonth} ▼</Ic.MonthTitle>
+                <Ic.MonthTitle onClick={() => setIsDropdownOpen((prev) => !prev)}>{selectedMonth} ▼</Ic.MonthTitle>
                 {isDropdownOpen && (
                     <Ic.Dropdown>
-                        {months.map((month) => (
+                        {availableMonths.map((month) => (
                             <Ic.DropdownItem
                                 key={month}
                                 onClick={() => {
@@ -40,24 +70,30 @@ const InsightChart = () => {
                         ))}
                     </Ic.Dropdown>
                 )}
-                <Ic.ChartBox>
-                    <Ic.ChartBarGroup>
-                        {dummyData.levels.map((value, i) => (
-                            <Ic.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
-                        ))}
-                    </Ic.ChartBarGroup>
-                    <Ic.ChartLabelGroup>
-                        {['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5', 'Level 6'].map((label, i) => (
-                            <div key={i}>{label}</div>
-                        ))}
-                    </Ic.ChartLabelGroup>
-                </Ic.ChartBox>
 
-                <Ic.FeedbackBox>
-                    {dummyData.comment.split('\n').map((line, index) => (
-                        <div key={index}>{line}</div>
-                    ))}
-                </Ic.FeedbackBox>
+                {selectedData && (
+                    <>
+                        <Ic.ChartBox>
+                            <Ic.ChartBarGroup>
+                                {selectedData.levels.map((value, i) => (
+                                    <Ic.ChartBar key={i} height={`${value * 90}px`} color={levelColors[i]} />
+                                ))}
+                            </Ic.ChartBarGroup>
+                            <Ic.ChartLabelGroup>
+                                {['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5', 'Level 6'].map((label, i) => (
+                                    <div key={i}>{label}</div>
+                                ))}
+                            </Ic.ChartLabelGroup>
+                        </Ic.ChartBox>
+
+                        {selectedData && (
+                            <Ic.FeedbackBox>
+                                {selectedData.comment ||
+                                    generatedComment.split('\n').map((line, index) => <div key={index}>{line}</div>)}
+                            </Ic.FeedbackBox>
+                        )}
+                    </>
+                )}
             </Ic.Content>
             <Footer />
         </Ic.Container>

--- a/src/pages/insight/InsightChartDesk.jsx
+++ b/src/pages/insight/InsightChartDesk.jsx
@@ -1,33 +1,63 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import * as Id from './InsightChartDeskStyles.jsx';
 import HomeDeskHeader from '../../components/header/HomeDeskHeader';
 import Sidebar from '../../components/sidebar/Sidebar';
 
 const InsightChartDesk = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const chartData = location.state?.chartData || [];
+    const selectedMonthFromNav = location.state?.selectedMonth;
 
     const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
-    const dummyData = {
-        month: '2025/01',
-        levels: [120, 180, 100, 80, 60, 40],
-        comment:
-            'B6님은 1월에 다양한 개념을 잘 이해하고 의미를 정확히 짚어냈어요.\n사고의 깊이가 점점 더해지고 있어요!',
-    };
 
-    const [selectedMonth, setSelectedMonth] = useState('2025/01');
+    const availableMonths = chartData.map((d) => d.month);
+    const [selectedMonth, setSelectedMonth] = useState(selectedMonthFromNav || availableMonths[0] || '');
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-    const months = ['2025/01', '2025/02', '2025/03', '2025/04', '2025/05', '2025/06'];
+    const selectedData = chartData.find((d) => d.month === selectedMonth);
+
+    const getMostFrequentLevel = (levels) => {
+        let maxCount = Math.max(...levels);
+        return levels.findIndex((v) => v === maxCount) + 1;
+    };
+
+    const levelComments = {
+        1: `이 달에는 학습한 개념들을 잘 기억하고, 주요 용어나 정의를 빠짐없이 떠올릴 수 있었습니다. 
+      이는 탄탄한 기초 이해를 위한 중요한 첫걸음이며, 꾸준한 복습과 반복 학습을 통해 더 깊은 사고로 확장될 수 있는 기반이 마련되었습니다.`,
+
+        2: `단순히 정보를 기억하는 데서 나아가, 그 의미와 맥락을 잘 파악하고 있었습니다. 
+      개념 간의 관계를 이해하고 설명할 수 있는 능력이 향상되었으며, 이는 사고의 뼈대를 세우는 중요한 단계입니다. 
+      앞으로 다양한 사례에 대한 해석과 설명을 시도해보면 더 좋은 성장을 기대할 수 있습니다.`,
+
+        3: `이 달에는 배운 개념을 실제 상황에 적용해보는 시도가 돋보였습니다. 
+      단순한 이해에 그치지 않고, 다양한 문제 상황에 맞게 지식을 유연하게 활용하는 모습이 인상적이었습니다. 
+      이러한 응용력은 사고의 실천적 전환점을 의미하며, 더 복잡한 문제에도 자신감을 가지고 접근할 수 있도록 이끕니다.`,
+
+        4: `개념이나 현상을 세분화하여 비교하거나 분류하고, 핵심 구조를 파악하려는 분석적 사고가 잘 드러났습니다. 
+      이 단계는 단순한 적용을 넘어서, 왜 그렇게 작동하는지를 이해하고 설명하려는 노력의 결과입니다. 
+      앞으로는 논리적 근거에 기반한 설명을 더 강화하면 심화된 분석 능력을 키울 수 있습니다.`,
+
+        5: `이 달에는 다양한 관점을 고려하여 평가하거나 판단하는 사고 수준에 도달했습니다. 
+      타당한 근거를 바탕으로 비교하고 결론을 내리는 과정에서 비판적 사고 역량이 향상되었고, 스스로의 사고를 성찰하는 능력 또한 강화되었습니다. 
+      더 넓은 시야에서 문제를 바라보는 연습을 지속하면 더욱 성숙한 사고가 가능할 것입니다.`,
+
+        6: `창의적인 아이디어를 제시하고, 기존의 개념들을 재구성하거나 새로운 방식으로 표현하려는 시도가 돋보였습니다. 
+      이는 블룸의 최상위 사고 수준에 해당하는 ‘창출’ 단계로, 스스로의 사고를 독립적이고 창의적으로 발전시킬 수 있다는 강력한 증거입니다. 
+      앞으로도 자유롭고 유연한 사고를 통해 새로운 관점과 해결책을 꾸준히 시도해 보세요.`,
+    };
+
+    const generatedComment = selectedData ? levelComments[getMostFrequentLevel(selectedData.levels)] : '';
 
     return (
         <Id.Container>
             <HomeDeskHeader />
             <Id.Content>
-                <Id.MonthTitle onClick={() => setIsDropdownOpen(!isDropdownOpen)}>{selectedMonth} ▼</Id.MonthTitle>
+                <Id.MonthTitle onClick={() => setIsDropdownOpen((prev) => !prev)}>{selectedMonth} ▼</Id.MonthTitle>
                 {isDropdownOpen && (
                     <Id.Dropdown>
-                        {months.map((month) => (
+                        {availableMonths.map((month) => (
                             <Id.DropdownItem
                                 key={month}
                                 onClick={() => {
@@ -40,24 +70,30 @@ const InsightChartDesk = () => {
                         ))}
                     </Id.Dropdown>
                 )}
-                <Id.ChartBox>
-                    <Id.ChartBarGroup>
-                        {dummyData.levels.map((value, i) => (
-                            <Id.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
-                        ))}
-                    </Id.ChartBarGroup>
-                    <Id.ChartLabelGroup>
-                        {['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5', 'Level 6'].map((label, i) => (
-                            <div key={i}>{label}</div>
-                        ))}
-                    </Id.ChartLabelGroup>
-                </Id.ChartBox>
 
-                <Id.FeedbackBox>
-                    {dummyData.comment.split('\n').map((line, index) => (
-                        <div key={index}>{line}</div>
-                    ))}
-                </Id.FeedbackBox>
+                {selectedData && (
+                    <>
+                        <Id.ChartBox>
+                            <Id.ChartBarGroup>
+                                {selectedData.levels.map((value, i) => (
+                                    <Id.ChartBar key={i} height={`${value * 90}px`} color={levelColors[i]} />
+                                ))}
+                            </Id.ChartBarGroup>
+                            <Id.ChartLabelGroup>
+                                {['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5', 'Level 6'].map((label, i) => (
+                                    <Id.ChartLabel key={i}>{label}</Id.ChartLabel>
+                                ))}
+                            </Id.ChartLabelGroup>
+                        </Id.ChartBox>
+
+                        {selectedData && (
+                            <Id.FeedbackBox>
+                                {selectedData.comment ||
+                                    generatedComment.split('\n').map((line, index) => <div key={index}>{line}</div>)}
+                            </Id.FeedbackBox>
+                        )}
+                    </>
+                )}
             </Id.Content>
             <Sidebar />
         </Id.Container>

--- a/src/pages/insight/InsightChartDeskStyles.jsx
+++ b/src/pages/insight/InsightChartDeskStyles.jsx
@@ -32,6 +32,8 @@ export const MonthTitle = styled.div`
 `;
 
 export const ChartBox = styled.div`
+    flex: 1;
+    margin: 0 4px;
     background-color: #f6f6f6;
     border-radius: 20px;
     padding: 20px;
@@ -52,12 +54,11 @@ export const ChartBarGroup = styled.div`
 `;
 
 export const ChartBar = styled.div`
-    width: 13%;
+    width: 12%;
     height: ${({ height }) => height};
     max-height: 280px;
     background-color: ${({ color }) => color};
     border-radius: 6px;
-    transition: height 0.3s;
 `;
 
 export const ChartLabelGroup = styled.div`
@@ -65,6 +66,15 @@ export const ChartLabelGroup = styled.div`
     justify-content: space-between;
     font-size: 12px;
     color: #444;
+    width: 100%;
+`;
+
+export const ChartLabel = styled.div`
+    flex: 1;
+    margin: 0 4px;
+    font-size: 12px;
+    color: #444;
+    text-align: center;
 `;
 
 export const FeedbackBox = styled.div`

--- a/src/pages/insight/InsightChartStyles.jsx
+++ b/src/pages/insight/InsightChartStyles.jsx
@@ -15,7 +15,7 @@ export const Container = styled.div`
 export const Content = styled.div`
     flex: 1;
     overflow-y: auto;
-    padding: 40px;
+    padding: 45px;
     margin-top: 18%;
 `;
 
@@ -63,8 +63,7 @@ export const ChartLabelGroup = styled.div`
 export const FeedbackBox = styled.div`
     background-color: #f6f6f6;
     border-radius: 20px;
-    padding: 30px;
-    font-weight: bold;
+    padding: 25px;
     font-size: 15px;
     color: #383636;
     line-height: 1.5;

--- a/src/pages/insight/InsightDesk.jsx
+++ b/src/pages/insight/InsightDesk.jsx
@@ -1,36 +1,63 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { getLevelProgressApi } from '../../api/insight/InsightApi';
 import * as I from './InsightDeskStyles.jsx';
 import HomeDeskHeader from '../../components/header/HomeDeskHeader';
 import Sidebar from '../../components/sidebar/Sidebar';
 
-const dummyData = [
-    { month: '2025/01', levels: [120, 200, 90, 70, 50, 30] },
-    { month: '2025/02', levels: [120, 200, 90, 70, 50, 30] },
-    { month: '2025/03', levels: [120, 200, 90, 70, 50, 30] },
-    { month: '2025/04', levels: [120, 200, 90, 70, 50, 30] },
-    { month: '2025/05', levels: [120, 200, 90, 70, 50, 30] },
-    { month: '2025/06', levels: [120, 200, 90, 70, 50, 30] },
-];
-
 const InsightDesk = () => {
     const navigate = useNavigate();
-
-    const goToInsightChart = () => {
-        navigate('/insightchart');
-    };
+    const token = useSelector((state) => state.user.token);
 
     const [term, setTerm] = useState('상반기');
     const [showDropdown, setShowDropdown] = useState(false);
+    const [chartData, setChartData] = useState([]);
 
     const toggleDropdown = () => setShowDropdown(!showDropdown);
     const selectTerm = (t) => {
         setTerm(t);
         setShowDropdown(false);
-        // 이후 서버에서 데이터 가져와야 함
     };
 
     const levelColors = ['#a6d5ff', '#8ec9ff', '#70baff', '#54aaff', '#3c9bff', '#248cff'];
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const res = await getLevelProgressApi(token);
+
+                // 월별 L1~L6 빈도 계산
+                const monthly = {};
+
+                res.forEach(({ startedAt, maxBloomLevel }) => {
+                    const date = new Date(startedAt);
+                    const yyyy = date.getFullYear();
+                    const mm = String(date.getMonth() + 1).padStart(2, '0');
+                    const key = `${yyyy}/${mm}`;
+
+                    if (!monthly[key]) monthly[key] = [0, 0, 0, 0, 0, 0]; // L1~L6
+
+                    if (maxBloomLevel >= 1 && maxBloomLevel <= 6) {
+                        monthly[key][maxBloomLevel - 1]++;
+                    }
+                });
+
+                const filtered = Object.entries(monthly)
+                    .filter(([month]) => {
+                        const m = parseInt(month.split('/')[1]);
+                        return term === '상반기' ? m <= 6 : m >= 7;
+                    })
+                    .map(([month, levels]) => ({ month, levels }));
+
+                setChartData(filtered.sort((a, b) => a.month.localeCompare(b.month)));
+            } catch (err) {
+                console.error('레벨 진행 데이터 불러오기 실패:', err);
+            }
+        };
+
+        fetchData();
+    }, [term, token]);
 
     return (
         <I.Container>
@@ -45,13 +72,23 @@ const InsightDesk = () => {
                         </I.Dropdown>
                     )}
                 </I.TermSelector>
-                <I.ChartGrid onClick={goToInsightChart}>
-                    {dummyData.map((data, index) => (
-                        <I.ChartBox key={index}>
+                <I.ChartGrid>
+                    {chartData.map((data, index) => (
+                        <I.ChartBox
+                            key={index}
+                            onClick={() =>
+                                navigate('/insightchart', {
+                                    state: {
+                                        chartData,
+                                        selectedMonth: data.month,
+                                    },
+                                })
+                            }
+                        >
                             <I.MonthText>{data.month}</I.MonthText>
                             <I.ChartBarGroup>
                                 {data.levels.map((value, i) => (
-                                    <I.ChartBar key={i} height={`${value}px`} color={levelColors[i]} />
+                                    <I.ChartBar key={i} height={`${value * 50}px`} color={levelColors[i]} />
                                 ))}
                             </I.ChartBarGroup>
                             <I.ChartLabelGroup>

--- a/src/pages/insight/InsightDeskStyles.jsx
+++ b/src/pages/insight/InsightDeskStyles.jsx
@@ -52,11 +52,12 @@ export const Content = styled.div`
 export const ChartGrid = styled.div`
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 40px 60px;
+    gap: 40px 70px;
     justify-content: center;
-    margin-top: 20px;
     cursor: pointer;
     width: 100%;
+    padding: 8%;
+    margin-top: -5%;
 `;
 
 export const ChartBox = styled.div`

--- a/src/pages/insight/InsightStyles.jsx
+++ b/src/pages/insight/InsightStyles.jsx
@@ -48,7 +48,7 @@ export const ChartGrid = styled.div`
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 20px;
-    margin-top: 20px;
+    margin-top: 30px;
     cursor: pointer;
 `;
 


### PR DESCRIPTION
# [feature/insight] 히스토그램 API 연동 및 인사이트 화면 전체 개선 (/insight, /insightchart 등)

## PR요약

해당 pr은
-   사용자 사고 레벨 분석을 위한 히스토그램 API를 연동했습니다.
-  `/insight` 및 `/insightchart` 관련 화면 전체 흐름을 구현·개선한 작업입니다.

## 관련 이슈

없음

## 작업 내용
-   `InsightApi.js`
    -   `getLevelProgressApi` 생성: 월별 Bloom 레벨 데이터를 조회하는 API 연동
-   `Insight.jsx`, `InsightDesk.jsx`
    -   API 연동 후 월별 L1~L6 빈도 시각화 (히스토그램) 구현
    -   선택한 월의 데이터를 `/insightchart`로 전달 (`chatData`, `selectedMonth`)
-   `InsightChart.jsx`, `InsightChartDesk.jsx`
    -   전달받은 월별 데이터를 기반으로 레벨별 막대그래프 렌더링
    -   가장 빈도 높은 레벨 기준 자동 분석 코멘트 출력 (levelComments 기반)
-   `InsightChartStyles.jsx`, `InsightChartDeskStyles.jsx`, `InsightStyles.jsx`, `InsightDeskStyles.jsx`
    -   전체 차트 구성 및 반응형 스타일링 조정

## 공유사항

-   각 월에 대한 분석 코멘트는 가장 빈도 높은 Bloom 레벨을 기준으로 자동 생성됩니다.
-   QA 시, 월별 데이터 누락/빈도 오류, 월 선택 시 렌더링 오류 등 확인 필요

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
