### PR TITLE
[Feat] 채팅방에서 기록 목록 클릭 시 해당 대화 기록 불러오기 로직 추가

### DIFF
--- a/src/pages/chat/ChatDeskScreen.jsx
+++ b/src/pages/chat/ChatDeskScreen.jsx
@@ -202,6 +202,44 @@ const ChatDesk = () => {
         initChat();
     }, [sessionId, token]);
 
+    useEffect(() => {
+        const fromRecordPage = !!location.state?.sessionId;
+
+        if (!fromRecordPage) return;
+
+        const loadPastChat = async () => {
+            try {
+                const data = await getChatHistoryApi(location.state.sessionId, token);
+
+                if (!data.messages || data.messages.length === 0) {
+                    throw new Error('기록 없음');
+                }
+
+                const formattedChat = data.messages
+                    .sort((a, b) => a.message_order - b.message_order)
+                    .map((msg) => ({
+                        sender: msg.speaker === 'AI' ? 'bot' : 'user',
+                        text: msg.content,
+                    }));
+
+                setChatLog(formattedChat);
+                setChatData({
+                    session_id: data.session_id,
+                    topic: data.topic,
+                    current_level: data.current_level,
+                });
+                setIsComplete(true);
+
+                localStorage.removeItem('latest_session_id');
+                localStorage.removeItem('latest_session_date');
+            } catch (err) {
+                console.error('기록 불러오기 실패:', err);
+            }
+        };
+
+        loadPastChat();
+    }, [location.state?.sessionId, token]);
+
     const scrollToBottom = () => {
         chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     };

--- a/src/pages/chat/ChatScreen.jsx
+++ b/src/pages/chat/ChatScreen.jsx
@@ -217,6 +217,44 @@ const Chat = () => {
         initChat();
     }, [sessionId, token]);
 
+    useEffect(() => {
+        const fromRecordPage = !!location.state?.sessionId;
+
+        if (!fromRecordPage) return;
+
+        const loadPastChat = async () => {
+            try {
+                const data = await getChatHistoryApi(location.state.sessionId, token);
+
+                if (!data.messages || data.messages.length === 0) {
+                    throw new Error('기록 없음');
+                }
+
+                const formattedChat = data.messages
+                    .sort((a, b) => a.message_order - b.message_order)
+                    .map((msg) => ({
+                        sender: msg.speaker === 'AI' ? 'bot' : 'user',
+                        text: msg.content,
+                    }));
+
+                setChatLog(formattedChat);
+                setChatData({
+                    session_id: data.session_id,
+                    topic: data.topic,
+                    current_level: data.current_level,
+                });
+                setIsComplete(true);
+
+                localStorage.removeItem('latest_session_id');
+                localStorage.removeItem('latest_session_date');
+            } catch (err) {
+                console.error('기록 불러오기 실패:', err);
+            }
+        };
+
+        loadPastChat();
+    }, [location.state?.sessionId, token]);
+
     const scrollToBottom = () => {
         chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     };


### PR DESCRIPTION
# [feature/chat] 채팅방에서 기록 목록 클릭 시 해당 대화 기록 불러오기 로직 추가

## PR요약

해당 pr은
-   기록 목록에서 특정 항목을 클릭했을 때, 해당 채팅 세션의 대화 기록을 `ChatScreen` 또는 `ChatDeskScreen` 화면에서 불러와 보여주는 기능을 추가한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `ChatScreen.jsx`, `ChatDeskScreen.jsx`
    -   `location.state?.sessionId`를 이용해 기록에서 전달된 세션 ID 확인
    -   `getChatHistoryApi` 호출로 해당 세션의 대화 메시지 불러오기 및 화면에 렌더링
    -   메시지 순서를 `message_order` 기준으로 정렬
    -   기록에서 진입한 경우에는 `localStorage`의 `latest_session_id`, `latest_session_date` 초기화

## 공유사항

-   기록 불러오기 시, 존재하지 않거나 유효하지 않은 세션 ID에 대한 예외 처리를 간단히 적용했습니다. 

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
